### PR TITLE
Fix ArrayStoreException in BaseItemBuilder placeholder handling

### DIFF
--- a/src/main/java/com/diamonddagger590/mccore/builder/item/BaseItemBuilder.java
+++ b/src/main/java/com/diamonddagger590/mccore/builder/item/BaseItemBuilder.java
@@ -1104,7 +1104,7 @@ public class BaseItemBuilder<B extends BaseItemBuilder<B>> {
      */
     @NotNull
     protected TagResolver[] getPlaceHolders(@Nullable CorePapiHook papiHook, @Nullable Audience audience) {
-        TagResolver[] placeholderArray = new TagResolver.Single[placeholders.size() + (papiHook != null && audience instanceof Player ? 1 : 0)];
+        TagResolver[] placeholderArray = new TagResolver[placeholders.size() + (papiHook != null && audience instanceof Player ? 1 : 0)];
         int index = 0;
         for (String key : placeholders.keySet()) {
             String value = placeholders.get(key);


### PR DESCRIPTION
While doing DiamondDagger590/McRPG#194 I ran into this issue.

- Fix `ArrayStoreException` when using PlaceholderAPI with GUI items

When a player with PlaceholderAPI installed opens a GUI (e.g., `/mcrpg`), an `ArrayStoreException` is thrown:

`java.lang.ArrayStoreException: net.kyori.adventure.text.minimessage.tag.resolver.TagResolver$1
at BaseItemBuilder.getPlaceHolders(BaseItemBuilder.java:1115)`


## Cause
In `getPlaceHolders()`, the array is declared as `TagResolver.Single[]` but `CorePapiHook.getTagResolver()` returns a `TagResolver` (not `TagResolver.Single`). Java arrays are covariant but enforce runtime type checking, causing the store to fail.

## Fix
Change the array instantiation from `new TagResolver.Single[...]` to `new TagResolver[...]`. Both `TagResolver.Single` and `TagResolver` can be stored in a `TagResolver[]` array.
