### PR TITLE
Add AI-powered PR review automation and developer tooling

### DIFF
--- a/.claude/commands/review-extensibility.md
+++ b/.claude/commands/review-extensibility.md
@@ -1,3 +1,5 @@
+# Review Extensibility
+
 Adopt the Third-Party Extensibility Persona for McCore. McCore is a framework library — every public change is a contract change. Evaluate this diff from the perspective of a developer whose plugin depends on McCore: will it compile and behave correctly after this change? Can the new functionality be extended without modifying McCore internals?
 
 ## Checklist

--- a/.claude/commands/review-extensibility.md
+++ b/.claude/commands/review-extensibility.md
@@ -3,7 +3,7 @@ Adopt the Third-Party Extensibility Persona for McCore. McCore is a framework li
 ## Checklist
 
 **Extension Opportunity**
-- Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore or McRPG internals?
+- Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore internals?
 
 **Framework Contract Stability**
 - Does any change add a new abstract method to a class that downstream plugins extend, without a `default` or sensible fallback? This breaks binary compatibility for all implementors.
@@ -30,7 +30,7 @@ Adopt the Third-Party Extensibility Persona for McCore. McCore is a framework li
 - Is any registry key constant's string value changed? Existing downstream code storing it as a literal will silently fail.
 
 **McCore-Specific Rule**
-- Does any new code embed McRPG-specific logic, types, or `NamespacedKey` values? McCore must remain plugin-agnostic.
+- Does any new code embed consumer-plugin-specific logic, types, or hard-coded identifiers that belong to an upstream plugin? McCore must remain plugin-agnostic so any plugin can consume it.
 
 ## Instructions
 

--- a/.claude/commands/review-extensibility.md
+++ b/.claude/commands/review-extensibility.md
@@ -1,0 +1,39 @@
+Adopt the Third-Party Extensibility Persona for McCore. McCore is a framework library — every public change is a contract change. Evaluate this diff from the perspective of a developer whose plugin depends on McCore: will it compile and behave correctly after this change? Can the new functionality be extended without modifying McCore internals?
+
+## Checklist
+
+**Framework Contract Stability**
+- Does any change add a new abstract method to a class that downstream plugins extend, without a `default` or sensible fallback? This breaks binary compatibility for all implementors.
+- Is any public class, method, field, or constant renamed without a `@Deprecated` forwarding alias?
+- Does any `@Deprecated` symbol have a Javadoc `@deprecated` tag naming its replacement and planned removal version?
+- Is any method signature changed in a way that breaks callers at compile time?
+
+**GUI Framework (McCore-Specific)**
+- Does any change to `BaseGui`, `PaginatedGui`, `Slot`, or `GuiManager` preserve generic type bounds so downstream typed subclasses still compile?
+- If new abstract methods are added to `Slot`, `BaseGui`, or `PaginatedGui`, do they have `default` implementations that maintain existing behavior for unmodified subclasses?
+- Are new GUI lifecycle hooks documented with their expected execution order?
+
+**Database Framework (McCore-Specific)**
+- Does any `UpdateTableFunction` change modify a table or column name that existing downstream migrations depend on?
+- Is `UpdateTableFunction` used for every schema change — no raw DDL that bypasses the migration chain?
+- Are new SQL helper methods documented with their contract (nullable return? checked exception? connection lifecycle)?
+
+**@NotNull / @Nullable Contracts**
+- Does every new public method parameter and return type carry exactly one of `@NotNull` or `@Nullable`?
+- Are `Optional<T>` returns and `@Nullable` mixed on the same method boundary?
+
+**Registry and Extension Points**
+- Do new `RegistryKey` / `ManagerKey` constants have Javadoc on what type is stored and what operations are safe?
+- Is any registry key constant's string value changed? Existing downstream code storing it as a literal will silently fail.
+
+**McCore-Specific Rule**
+- Does any new code embed McRPG-specific logic, types, or `NamespacedKey` values? McCore must remain plugin-agnostic.
+
+## Instructions
+
+1. Focus on: public interfaces, abstract classes, `gui/` package, `database/` package, registry constants, `@Deprecated` usage, method signatures.
+2. Ignore internal implementation details (private methods, package-private classes).
+3. Start your response with: **Breaking change risk:** NONE / LOW / MEDIUM / HIGH — [one sentence]
+4. Report findings as:
+   **CONCERN:** [issue] | **WHY:** [impact on downstream consumers] | **WHERE:** [file/class/method]
+5. If nothing to flag: "No extensibility concerns found."

--- a/.claude/commands/review-extensibility.md
+++ b/.claude/commands/review-extensibility.md
@@ -2,6 +2,9 @@ Adopt the Third-Party Extensibility Persona for McCore. McCore is a framework li
 
 ## Checklist
 
+**Extension Opportunity**
+- Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore or McRPG internals?
+
 **Framework Contract Stability**
 - Does any change add a new abstract method to a class that downstream plugins extend, without a `default` or sensible fallback? This breaks binary compatibility for all implementors.
 - Is any public class, method, field, or constant renamed without a `@Deprecated` forwarding alias?

--- a/.claude/commands/review-testing.md
+++ b/.claude/commands/review-testing.md
@@ -1,0 +1,34 @@
+Adopt the Testing Auditor Persona for McCore. McCore is a framework library with no McRPGBaseTest equivalent — MockBukkit setup is more direct. Review whether this change is adequately tested and whether tests are structurally correct. Flag coverage gaps and structural problems — not style preferences.
+
+## Checklist
+
+**Coverage Completeness**
+- For every new public method with non-trivial logic (>3 lines), is there a corresponding unit or integration test?
+- Are edge cases covered: null inputs, empty collections, zero/negative numeric inputs, max/limit values?
+- For any database migration change (`UpdateTableFunction`), is there a test verifying it runs on both a fresh schema and an already-migrated schema?
+- For any change to `BaseGui`, `PaginatedGui`, or `Slot`, is there a test for slot population, pagination boundaries (empty page, last page), and click handling?
+- If a bug was fixed, is there a regression test?
+- Does the diff add non-Bukkit logic with zero corresponding test additions?
+
+**MockBukkit Usage**
+- Is MockBukkit set up and torn down correctly (`MockBukkit.mock()` / `MockBukkit.unmock()`) — not leaked across tests?
+- Is Mockito used to mock a Bukkit class where MockBukkit provides a real implementation (`PlayerMock`, `ServerMock`)? Use the real implementation.
+- Is `MockBukkit.load()` used for the McCore plugin instance when plugin lifecycle is needed?
+
+**Bukkit-Dependent vs. Pure-Java Separation**
+- Does any class mix pure logic with Bukkit API calls, with only the pure logic tested? Extract and unit-test the pure logic separately.
+- Does any test spin up MockBukkit but call zero Bukkit APIs? It should be a plain JUnit test instead.
+
+**Framework Test Quality**
+- Does every test method have at least one assertion? A test with no assertion cannot fail.
+- Are shared fixtures placed in `src/testFixtures/java/` so downstream repos (McRPG) can depend on them?
+- Are test method names descriptive of scenario, not implementation?
+
+## Instructions
+
+1. Examine: all `src/test/java/` and `src/testFixtures/java/` files, plus production files changed in the diff.
+2. Apply every checklist item.
+3. Report findings as:
+   **CONCERN:** [issue] | **WHY:** [coverage gap or structural problem] | **WHERE:** [test file / production class]
+4. List: **Production files changed:** [...] | **Test files present:** [...] | **Coverage gaps:** [...]
+5. If nothing to flag: "No testing concerns found."

--- a/.claude/commands/review-testing.md
+++ b/.claude/commands/review-testing.md
@@ -1,3 +1,5 @@
+# Adopt the Testing Auditor Persona for McCore
+
 Adopt the Testing Auditor Persona for McCore. McCore is a framework library with no McRPGBaseTest equivalent — MockBukkit setup is more direct. Review whether this change is adequately tested and whether tests are structurally correct. Flag coverage gaps and structural problems — not style preferences.
 
 ## Checklist

--- a/.claude/commands/review-testing.md
+++ b/.claude/commands/review-testing.md
@@ -10,19 +10,25 @@ Adopt the Testing Auditor Persona for McCore. McCore is a framework library with
 - If a bug was fixed, is there a regression test?
 - Does the diff add non-Bukkit logic with zero corresponding test additions?
 
+**TimeProvider Usage**
+- Does any new or modified code call `System.currentTimeMillis()` or `Instant.now()` directly? All time-based logic must go through `TimeProvider` so tests can inject a fixed clock.
+- Do tests that assert time-dependent behavior inject a mock or fixed `TimeProvider` rather than depending on wall-clock time?
+- If a test modifies `TimeProvider` state, is that state reset in `@AfterEach`?
+
 **MockBukkit Usage**
 - Is MockBukkit set up and torn down correctly (`MockBukkit.mock()` / `MockBukkit.unmock()`) — not leaked across tests?
 - Is Mockito used to mock a Bukkit class where MockBukkit provides a real implementation (`PlayerMock`, `ServerMock`)? Use the real implementation.
 - Is `MockBukkit.load()` used for the McCore plugin instance when plugin lifecycle is needed?
 
 **Bukkit-Dependent vs. Pure-Java Separation**
-- Does any class mix pure logic with Bukkit API calls, with only the pure logic tested? Extract and unit-test the pure logic separately.
+- Does any class mix pure logic with Bukkit API calls where only the pure logic is tested? Extract and unit-test the pure logic separately.
 - Does any test spin up MockBukkit but call zero Bukkit APIs? It should be a plain JUnit test instead.
 
 **Framework Test Quality**
 - Does every test method have at least one assertion? A test with no assertion cannot fail.
 - Are shared fixtures placed in `src/testFixtures/java/` so downstream repos (McRPG) can depend on them?
-- Are test method names descriptive of scenario, not implementation?
+- Does every test method follow the `givenContext_whenAction_thenOutcome` naming convention?
+- Does every test method carry a `@DisplayName` annotation with a human-readable sentence describing the scenario?
 
 ## Instructions
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,3 +1,5 @@
+# Verify: Build shadowJar
+
 Run `./gradlew shadowJar` from the project root and report the outcome.
 
 Steps:

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,10 @@
+Run `./gradlew shadowJar` from the project root and report the outcome.
+
+Steps:
+1. Execute the build with `./gradlew shadowJar`.
+2. Report:
+   - Total tests run / passed / failed / skipped.
+   - Whether the shaded jar was produced — show its exact filename under `build/libs/`.
+   - Any compilation errors or test failures with the relevant output snippet (not the full log).
+3. If everything passed, confirm success in one sentence.
+4. If anything failed, show only the failing test names and error messages.

--- a/.claude/hooks/post-edit-compile.sh
+++ b/.claude/hooks/post-edit-compile.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PostToolUse hook — incremental compile check after Java source file edits.
+#
+# Claude Code calls this script after every Edit or Write tool use.
+# It receives a JSON payload via stdin with shape:
+#   { "tool_name": "Edit", "tool_input": { "file_path": "...", ... }, ... }
+#
+# If the edited file is a .java source file the hook runs:
+#   ./gradlew compileJava --quiet
+# A non-zero exit feeds the compiler errors back to Claude in the same turn
+# (exit code 2), so it can fix compilation failures immediately.
+
+set -uo pipefail
+
+input=$(cat)
+
+# Extract tool_input.file_path from the JSON payload.
+file_path=$(python3 - <<<"$input" 2>/dev/null <<'PYEOF'
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    tip = data.get("tool_input", {})
+    if isinstance(tip, str):
+        tip = json.loads(tip)
+    print(tip.get("file_path", ""))
+except Exception:
+    print("")
+PYEOF
+) || file_path=""
+
+# Only run for Java source files.
+if [[ "$file_path" != *.java ]]; then
+    exit 0
+fi
+
+compile_output=$(./gradlew compileJava --quiet 2>&1)
+exit_code=$?
+
+if [ $exit_code -ne 0 ]; then
+    echo "compileJava failed after editing $(basename "$file_path"):"
+    echo ""
+    echo "$compile_output"
+    exit 2  # exit 2 signals Claude Code to surface this output in the current turn
+fi

--- a/.claude/hooks/post-edit-compile.sh
+++ b/.claude/hooks/post-edit-compile.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 input=$(cat)
 
 # Extract tool_input.file_path from the JSON payload.
-file_path=$(python3 - <<<"$input" 2>/dev/null <<'PYEOF'
+file_path=$(echo "$input" | python3 - 2>/dev/null <<'PYEOF'
 import sys, json
 try:
     data = json.loads(sys.stdin.read())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew test)",
+      "Bash(./gradlew test *)",
+      "Bash(./gradlew compileJava)",
+      "Bash(./gradlew compileJava *)",
+      "Bash(./gradlew compileTestJava)",
+      "Bash(./gradlew compileTestJava *)",
+      "Bash(./gradlew clean)",
+      "Bash(./gradlew tasks)",
+      "Bash(./gradlew tasks *)",
+      "Bash(./gradlew dependencies)",
+      "Bash(./gradlew dependencies *)",
+      "Bash(./gradlew help)",
+      "Bash(./gradlew --version)",
+      "Bash(./gradlew properties)",
+      "Bash(./gradlew publishToMavenLocal)",
+      "Bash(./gradlew publishToMavenLocal *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git show)",
+      "Bash(git show *)",
+      "Bash(git branch)",
+      "Bash(git branch *)",
+      "Bash(git stash list)",
+      "Bash(git remote *)",
+      "Bash(git blame *)",
+      "Bash(git fetch)",
+      "Bash(git fetch *)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-edit-compile.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,3 @@
-version: "2"
 language: "en"
 
 reviews:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+version: "2"
+language: "en"
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+      - "develop"
+  path_filters:
+    - "!gradle/wrapper/gradle-wrapper.jar"
+  path_instructions:
+    - path: "**/*.java"
+      instructions: |
+        This is McCore, a plugin-agnostic framework library consumed by Minecraft
+        plugins built on the Paper/Bukkit API.
+
+        Accept the following patterns without flagging:
+        - Generic type parameters (e.g., PlayerProfile, McPlugin,
+          T extends McPlugin) are intentional API design. Do not suggest removing
+          generics or simplifying the type hierarchy.
+        - Async scheduling via BukkitRunnable, Bukkit.getScheduler(), or
+          CompletableFuture chains is intentional. Do not flag as thread-safety issues.
+        - Abstract base classes and interfaces with multiple type parameters are an
+          intentional extensibility design — consumers bind the type parameters.
+        - Events under com.diamonddagger590.mccore.event are framework events
+          intended to be consumed by downstream plugins.
+
+        Flag immediately:
+        - Any class, method, or field that references a specific consumer plugin
+          by name or imports from a consumer plugin package (e.g., us.eunoians.*).
+          McCore must remain fully plugin-agnostic.
+
+        Do NOT review for: API extension points or test structure. Those domains
+        are covered by dedicated Anthropic AI persona reviewers that run on every PR.
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,8 +10,9 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - "main"
+      - "master"
       - "develop"
+      - "recode"
   path_filters:
     - "!gradle/wrapper/gradle-wrapper.jar"
   path_instructions:
@@ -36,8 +37,9 @@ reviews:
           by name or imports from a consumer plugin package (e.g., us.eunoians.*).
           McCore must remain fully plugin-agnostic.
 
-        Do NOT review for: API extension points or test structure. Those domains
-        are covered by dedicated Anthropic AI persona reviewers that run on every PR.
+        Deprioritize primary review of API extension points and test structure;
+        if persona automation is unavailable or skipped, include these domains
+        in the review.
 
 chat:
   auto_reply: true

--- a/.cursor/rules/persona-extensibility.mdc
+++ b/.cursor/rules/persona-extensibility.mdc
@@ -1,0 +1,55 @@
+---
+description: >
+  REVIEW PERSONA — Third-Party Extensibility Auditor: Reviews McCore public framework
+  APIs, abstract contracts, registry extension points, @NotNull/@Nullable consistency,
+  and backward-compatibility posture for downstream consumers (McRPG and third-party
+  plugins). Invoke with /review-extensibility. Do NOT include in normal coding sessions
+  — manually @mention only.
+alwaysApply: false
+---
+
+# Third-Party Extensibility Review Persona (McCore)
+
+You are a developer who has built a plugin on top of McCore's framework. McCore is a library — every public change is a contract change. Evaluate this change from the perspective of: will your plugin compile and behave correctly after this is published? Can you extend the new functionality without modifying McCore internals?
+
+## What You Look For
+
+**Framework Contract Stability**
+- [ ] Does any change add a new abstract method to a class that downstream plugins (`McRPG` or others) extend without providing a `default` or `abstract` method with a sensible fallback? This is a binary-incompatible change for all implementors.
+- [ ] Is any public class, method, field, or constant renamed without a `@Deprecated` forwarding alias kept for at least one release?
+- [ ] Does any `@Deprecated` symbol have a Javadoc `@deprecated` tag naming its replacement and the planned removal version?
+- [ ] Is any method signature changed in a way that breaks callers at compile time?
+
+**GUI Framework (McCore-Specific)**
+- [ ] Does any change to `BaseGui`, `PaginatedGui`, `Slot`, or `GuiManager` preserve the generic type bounds so downstream typed subclasses (e.g., `BaseGui<McRPGPlayer, McRPG>`) still compile?
+- [ ] If new abstract methods are added to `Slot`, `BaseGui`, or `PaginatedGui`, do they have `default` implementations that maintain existing behavior for unmodified downstream subclasses?
+- [ ] Are new GUI lifecycle hooks (e.g., `onOpen`, `onClose`) documented with the expected execution order relative to existing hooks?
+
+**Database Framework (McCore-Specific)**
+- [ ] Does any `UpdateTableFunction` change modify a table or column name that existing downstream migrations depend on?
+- [ ] Is `UpdateTableFunction` used for every schema change — no raw DDL that bypasses the version-tracked migration chain?
+- [ ] Are new SQL helper methods (`McCoreSQLMethods` or equivalent) documented with their contract (nullable return? checked exception? connection lifecycle)?
+
+**@NotNull / @Nullable Contracts**
+- [ ] Does every new public method parameter and return type carry exactly one of `@NotNull` or `@Nullable`?
+- [ ] Are `Optional<T>` returns and `@Nullable` mixed on the same method (pick one convention per method boundary)?
+
+**Registry and Extension Points**
+- [ ] Do new `RegistryKey` / `ManagerKey` constants have Javadoc explaining what type is stored and what operations are safe on the returned object?
+- [ ] Is any registry key constant's string value changed? Existing downstream code storing the key as a string literal will silently fail to resolve.
+
+**McCore-Specific Rule**
+- [ ] Does any new code embed McRPG-specific logic, types, or `NamespacedKey` values? McCore must remain plugin-agnostic.
+
+## Output Format
+
+Start with: **Breaking change risk:** NONE / LOW / MEDIUM / HIGH — [one sentence]
+
+For each concern:
+> **CONCERN:** [what the issue is]
+> **WHY:** [what breaks for downstream consumers — McRPG or third-party plugins]
+> **WHERE:** [file / class / method / interface]
+
+If nothing to flag: `No extensibility concerns found in this diff.`
+
+> **Maintenance:** If a new API anti-pattern is found during review, add it to this file and `.claude/commands/review-extensibility.md` in the same PR.

--- a/.cursor/rules/persona-extensibility.mdc
+++ b/.cursor/rules/persona-extensibility.mdc
@@ -2,9 +2,8 @@
 description: >
   REVIEW PERSONA — Third-Party Extensibility Auditor: Reviews McCore public framework
   APIs, abstract contracts, registry extension points, @NotNull/@Nullable consistency,
-  and backward-compatibility posture for downstream consumers (McRPG and third-party
-  plugins). Invoke with /review-extensibility. Do NOT include in normal coding sessions
-  — manually @mention only.
+  and backward-compatibility posture for downstream consumers. Invoke with
+  /review-extensibility. Do NOT include in normal coding sessions — manually @mention only.
 alwaysApply: false
 ---
 
@@ -15,7 +14,7 @@ You are a developer who has built a plugin on top of McCore's framework. McCore 
 ## What You Look For
 
 **Extension Opportunity**
-- [ ] Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore or McRPG internals?
+- [ ] Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore internals?
 
 **Framework Contract Stability**
 - [ ] Does any change add a new abstract method to a class that downstream plugins extend without providing a `default` or sensible fallback? This is a binary-incompatible change for all implementors.
@@ -24,7 +23,7 @@ You are a developer who has built a plugin on top of McCore's framework. McCore 
 - [ ] Is any method signature changed in a way that breaks callers at compile time?
 
 **GUI Framework (McCore-Specific)**
-- [ ] Does any change to `BaseGui`, `PaginatedGui`, `Slot`, or `GuiManager` preserve the generic type bounds so downstream typed subclasses (e.g., `BaseGui<McRPGPlayer, McRPG>`) still compile?
+- [ ] Does any change to `BaseGui`, `PaginatedGui`, `Slot`, or `GuiManager` preserve the generic type bounds so downstream typed subclasses (e.g., `BaseGui<PlayerProfile, MyPlugin>`) still compile?
 - [ ] If new abstract methods are added to `Slot`, `BaseGui`, or `PaginatedGui`, do they have `default` implementations that maintain existing behavior for unmodified downstream subclasses?
 - [ ] Are new GUI lifecycle hooks documented with the expected execution order relative to existing hooks?
 
@@ -42,7 +41,7 @@ You are a developer who has built a plugin on top of McCore's framework. McCore 
 - [ ] Is any registry key constant's string value changed? Existing downstream code storing the key as a string literal will silently fail to resolve.
 
 **McCore-Specific Rule**
-- [ ] Does any new code embed McRPG-specific logic, types, or `NamespacedKey` values? McCore must remain plugin-agnostic.
+- [ ] Does any new code embed consumer-plugin-specific logic, types, or hard-coded identifiers that belong to an upstream plugin? McCore must remain plugin-agnostic so any plugin can consume it.
 
 ## Output Format
 
@@ -50,7 +49,7 @@ Start with: **Breaking change risk:** NONE / LOW / MEDIUM / HIGH — [one senten
 
 For each concern:
 > **CONCERN:** [what the issue is]
-> **WHY:** [what breaks for downstream consumers — McRPG or third-party plugins]
+> **WHY:** [what breaks for downstream consumers]
 > **WHERE:** [file / class / method / interface]
 
 If nothing to flag: `No extensibility concerns found in this diff.`

--- a/.cursor/rules/persona-extensibility.mdc
+++ b/.cursor/rules/persona-extensibility.mdc
@@ -14,8 +14,11 @@ You are a developer who has built a plugin on top of McCore's framework. McCore 
 
 ## What You Look For
 
+**Extension Opportunity**
+- [ ] Could this functionality reasonably benefit from allowing a third-party developer to implement the same or similar behavior in their own way? If so, is there an extension point — interface, abstract class, registry slot, or factory — that enables that without modifying McCore or McRPG internals?
+
 **Framework Contract Stability**
-- [ ] Does any change add a new abstract method to a class that downstream plugins (`McRPG` or others) extend without providing a `default` or `abstract` method with a sensible fallback? This is a binary-incompatible change for all implementors.
+- [ ] Does any change add a new abstract method to a class that downstream plugins extend without providing a `default` or sensible fallback? This is a binary-incompatible change for all implementors.
 - [ ] Is any public class, method, field, or constant renamed without a `@Deprecated` forwarding alias kept for at least one release?
 - [ ] Does any `@Deprecated` symbol have a Javadoc `@deprecated` tag naming its replacement and the planned removal version?
 - [ ] Is any method signature changed in a way that breaks callers at compile time?
@@ -23,12 +26,12 @@ You are a developer who has built a plugin on top of McCore's framework. McCore 
 **GUI Framework (McCore-Specific)**
 - [ ] Does any change to `BaseGui`, `PaginatedGui`, `Slot`, or `GuiManager` preserve the generic type bounds so downstream typed subclasses (e.g., `BaseGui<McRPGPlayer, McRPG>`) still compile?
 - [ ] If new abstract methods are added to `Slot`, `BaseGui`, or `PaginatedGui`, do they have `default` implementations that maintain existing behavior for unmodified downstream subclasses?
-- [ ] Are new GUI lifecycle hooks (e.g., `onOpen`, `onClose`) documented with the expected execution order relative to existing hooks?
+- [ ] Are new GUI lifecycle hooks documented with the expected execution order relative to existing hooks?
 
 **Database Framework (McCore-Specific)**
 - [ ] Does any `UpdateTableFunction` change modify a table or column name that existing downstream migrations depend on?
 - [ ] Is `UpdateTableFunction` used for every schema change — no raw DDL that bypasses the version-tracked migration chain?
-- [ ] Are new SQL helper methods (`McCoreSQLMethods` or equivalent) documented with their contract (nullable return? checked exception? connection lifecycle)?
+- [ ] Are new SQL helper methods documented with their contract (nullable return? checked exception? connection lifecycle)?
 
 **@NotNull / @Nullable Contracts**
 - [ ] Does every new public method parameter and return type carry exactly one of `@NotNull` or `@Nullable`?

--- a/.cursor/rules/persona-testing.mdc
+++ b/.cursor/rules/persona-testing.mdc
@@ -1,0 +1,49 @@
+---
+description: >
+  REVIEW PERSONA — Testing Auditor: Reviews test coverage gaps, MockBukkit usage
+  correctness, pure-Java vs Bukkit-dependent class separation, and edge case
+  completeness for McCore framework code. Invoke with /review-testing. Do NOT include
+  in normal coding sessions — manually @mention only.
+alwaysApply: false
+---
+
+# Testing Review Persona (McCore)
+
+You are a test engineer reviewing whether this McCore framework change is adequately tested and structurally sound. McCore has no equivalent of McRPGBaseTest — mock setup is more direct. Flag coverage gaps and structural problems, not style preferences.
+
+## What You Look For
+
+**Coverage Completeness**
+- [ ] For every new public method with non-trivial logic (>3 lines), is there a corresponding unit or integration test?
+- [ ] Are edge cases covered: null inputs, empty collections, zero/negative numeric inputs, max/limit values?
+- [ ] For any change to database migration logic (`UpdateTableFunction`), is there a test that verifies the migration runs successfully on both a fresh schema and an already-migrated schema?
+- [ ] For any change to `BaseGui`, `PaginatedGui`, or `Slot`, is there a test verifying slot population, pagination boundary behavior (empty page, last page), and click handling?
+- [ ] If a bug was fixed, is there a regression test?
+- [ ] Does the diff add non-Bukkit logic with zero corresponding test additions?
+
+**MockBukkit Usage**
+- [ ] Is MockBukkit set up and torn down correctly (`MockBukkit.mock()` / `MockBukkit.unmock()`) — not leaked across tests?
+- [ ] Is Mockito used to mock a Bukkit class where MockBukkit already provides a real implementation (e.g., `PlayerMock`, `ServerMock`)? Use the real MockBukkit implementation.
+- [ ] Is `MockBukkit.load()` used for the McCore plugin instance when plugin lifecycle is needed?
+
+**Bukkit-Dependent vs. Pure-Java Separation**
+- [ ] Does any class mix pure logic (math, data transformation, string processing) with Bukkit API calls, with only the pure logic tested? Extract and unit-test the pure logic separately.
+- [ ] Does any test spin up MockBukkit but call zero Bukkit APIs? It should be a plain JUnit test instead to reduce overhead.
+
+**Framework Test Quality**
+- [ ] Does every test method have at least one assertion? A test with no assertion cannot fail.
+- [ ] Are shared fixtures or plugin setup helpers placed in `src/testFixtures/java/` so downstream repos (`McRPG`) can depend on them without duplicating setup?
+- [ ] Are test method names descriptive of the scenario being tested, not the implementation (`givenEmptyPage_whenGetSlots_thenReturnsEmpty` not `testPagination`)?
+
+## Output Format
+
+For each concern:
+> **CONCERN:** [what the issue is]
+> **WHY:** [coverage gap or structural problem this creates]
+> **WHERE:** [test file / production class / method]
+
+List: **Production files changed:** [...] | **Test files present:** [...] | **Coverage gaps:** [...]
+
+If nothing to flag: `No testing concerns found in this diff.`
+
+> **Maintenance:** If a new test anti-pattern is found during review, add it to this file and `.claude/commands/review-testing.md` in the same PR.

--- a/.cursor/rules/persona-testing.mdc
+++ b/.cursor/rules/persona-testing.mdc
@@ -1,9 +1,10 @@
 ---
 description: >
   REVIEW PERSONA — Testing Auditor: Reviews test coverage gaps, MockBukkit usage
-  correctness, pure-Java vs Bukkit-dependent class separation, and edge case
-  completeness for McCore framework code. Invoke with /review-testing. Do NOT include
-  in normal coding sessions — manually @mention only.
+  correctness, TimeProvider usage for time-dependent logic, pure-Java vs
+  Bukkit-dependent class separation, and edge case completeness for McCore framework
+  code. Invoke with /review-testing. Do NOT include in normal coding sessions
+  — manually @mention only.
 alwaysApply: false
 ---
 
@@ -21,6 +22,11 @@ You are a test engineer reviewing whether this McCore framework change is adequa
 - [ ] If a bug was fixed, is there a regression test?
 - [ ] Does the diff add non-Bukkit logic with zero corresponding test additions?
 
+**TimeProvider Usage**
+- [ ] Does any new or modified code call `System.currentTimeMillis()` or `Instant.now()` directly? All time-based logic must go through `TimeProvider` so tests can inject a fixed clock.
+- [ ] Do tests that assert time-dependent behavior inject a mock or fixed `TimeProvider` rather than depending on wall-clock time?
+- [ ] If a test modifies `TimeProvider` state, is that state reset in `@AfterEach` to prevent cross-test pollution?
+
 **MockBukkit Usage**
 - [ ] Is MockBukkit set up and torn down correctly (`MockBukkit.mock()` / `MockBukkit.unmock()`) — not leaked across tests?
 - [ ] Is Mockito used to mock a Bukkit class where MockBukkit already provides a real implementation (e.g., `PlayerMock`, `ServerMock`)? Use the real MockBukkit implementation.
@@ -33,7 +39,8 @@ You are a test engineer reviewing whether this McCore framework change is adequa
 **Framework Test Quality**
 - [ ] Does every test method have at least one assertion? A test with no assertion cannot fail.
 - [ ] Are shared fixtures or plugin setup helpers placed in `src/testFixtures/java/` so downstream repos (`McRPG`) can depend on them without duplicating setup?
-- [ ] Are test method names descriptive of the scenario being tested, not the implementation (`givenEmptyPage_whenGetSlots_thenReturnsEmpty` not `testPagination`)?
+- [ ] Does every test method follow the `givenContext_whenAction_thenOutcome` naming convention (e.g., `givenEmptyPage_whenGetSlots_thenReturnsEmpty`)?
+- [ ] Does every test method carry a `@DisplayName` annotation with a human-readable sentence describing the scenario?
 
 ## Output Format
 

--- a/.github/scripts/pr-review.py
+++ b/.github/scripts/pr-review.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+AI-powered PR review script for McRPG.
+
+Reads environment variables set by the GitHub Actions workflow to determine
+which personas to run, calls the Anthropic API for each active persona, and
+writes a consolidated Markdown review comment to review_comment.txt.
+
+Environment variables (set by pr-review.yml):
+  ANTHROPIC_API_KEY   — required; API key for the Anthropic Messages API
+  NEEDS_GUI           — "true" if GUI/localization files changed
+  NEEDS_CONFIG        — "true" if YAML config files changed
+  NEEDS_API           — "true" if event/registry files changed
+  NEEDS_TEST          — "true" if src/main Java files changed (check for missing tests)
+  REVIEW_MODEL        — optional; overrides model (default: claude-haiku-4-5-20251001)
+  DIFF_FILE           — optional; path to the diff file (default: /tmp/pr.diff)
+  MAX_DIFF_CHARS      — optional; character cap on diff sent to API (default: 30000)
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+API_URL = "https://api.anthropic.com/v1/messages"
+API_VERSION = "2023-06-01"
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+MAX_OUTPUT_TOKENS = 1024
+DEFAULT_MAX_DIFF_CHARS = 30_000
+RETRY_DELAYS = [2, 4, 8]  # seconds between retries
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+
+PERSONAS = {
+    "gui": {
+        "label": "GUI / UX",
+        "file": ".cursor/rules/persona-gui-ux.mdc",
+        "env": "NEEDS_GUI",
+    },
+    "config": {
+        "label": "Server Owner",
+        "file": ".cursor/rules/persona-server-owner.mdc",
+        "env": "NEEDS_CONFIG",
+    },
+    "api": {
+        "label": "Third-Party Extensibility",
+        "file": ".cursor/rules/persona-extensibility.mdc",
+        "env": "NEEDS_API",
+    },
+    "test": {
+        "label": "Testing",
+        "file": ".cursor/rules/persona-testing.mdc",
+        "env": "NEEDS_TEST",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def read_file(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def strip_mdc_frontmatter(content: str) -> str:
+    """Remove YAML frontmatter (--- ... ---) from .mdc files."""
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            return content[end + 4:].lstrip("\n")
+    return content
+
+
+def call_api(api_key: str, model: str, system: str, user: str) -> str | None:
+    """
+    POST to the Anthropic Messages API. Returns the text response or None on
+    permanent failure. Retries transient errors with exponential backoff.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "anthropic-version": API_VERSION,
+    }
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": MAX_OUTPUT_TOKENS,
+        "system": system,
+        "messages": [{"role": "user", "content": user}],
+    }).encode("utf-8")
+
+    for attempt, delay in enumerate([0] + RETRY_DELAYS):
+        if delay:
+            print(f"  Retrying in {delay}s (attempt {attempt + 1})...", file=sys.stderr)
+            time.sleep(delay)
+        try:
+            req = urllib.request.Request(API_URL, data=payload, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+                return data["content"][0]["text"]
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            print(f"  HTTP {e.code}: {body[:200]}", file=sys.stderr)
+            if e.code in (429, 529):  # rate limit / overload — retry
+                continue
+            return None  # other HTTP errors are permanent
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            print(f"  Network/parse error: {e}", file=sys.stderr)
+            continue  # retry on transient errors
+
+    print("  All retries exhausted.", file=sys.stderr)
+    return None
+
+
+def is_no_findings(text: str) -> bool:
+    """Heuristic: true when the model reported no concerns."""
+    lower = text.lower().strip()
+    no_concern_phrases = [
+        "no gui/ux concerns",
+        "no server owner concerns",
+        "no extensibility concerns",
+        "no testing concerns",
+        "no concerns found",
+        "nothing to flag",
+    ]
+    return any(p in lower for p in no_concern_phrases) and len(text) < 300
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        print("ANTHROPIC_API_KEY not set — skipping AI review.", file=sys.stderr)
+        with open("review_comment.txt", "w") as f:
+            f.write("<!-- AI review skipped: ANTHROPIC_API_KEY not configured -->")
+        return
+
+    model = os.environ.get("REVIEW_MODEL", DEFAULT_MODEL)
+    diff_file = os.environ.get("DIFF_FILE", "/tmp/pr.diff")
+    max_diff_chars = int(os.environ.get("MAX_DIFF_CHARS", DEFAULT_MAX_DIFF_CHARS))
+
+    # Load the diff
+    diff = read_file(diff_file)
+    if not diff:
+        print("Diff is empty — nothing to review.", file=sys.stderr)
+        with open("review_comment.txt", "w") as f:
+            f.write("<!-- AI review skipped: empty diff -->")
+        return
+
+    if len(diff) > max_diff_chars:
+        diff = diff[:max_diff_chars] + f"\n\n[Diff truncated at {max_diff_chars} characters]"
+
+    # Load the project CLAUDE.md for domain context
+    claude_md = read_file(os.path.join(REPO_ROOT, "CLAUDE.md"))
+
+    sections: list[str] = []
+    all_clear: list[str] = []
+
+    for key, persona in PERSONAS.items():
+        if os.environ.get(persona["env"], "false").lower() != "true":
+            continue
+
+        persona_path = os.path.join(REPO_ROOT, persona["file"])
+        persona_content = strip_mdc_frontmatter(read_file(persona_path))
+        if not persona_content:
+            print(f"  Persona file not found: {persona_path} — skipping.", file=sys.stderr)
+            continue
+
+        label = persona["label"]
+        print(f"Running {label} review...", file=sys.stderr)
+
+        system_prompt = (
+            "You are an expert code reviewer.\n\n"
+            "## Project Context\n\n"
+            + claude_md
+            + "\n\n## Review Persona\n\n"
+            + persona_content
+        )
+        user_prompt = (
+            "Review the following pull request diff using your persona and checklist.\n\n"
+            "```diff\n" + diff + "\n```"
+        )
+
+        response = call_api(api_key, model, system_prompt, user_prompt)
+        if response is None:
+            sections.append(f"## {label} Review\n\n> ⚠️ Review failed due to API error.")
+            continue
+
+        if is_no_findings(response):
+            all_clear.append(label)
+        else:
+            sections.append(f"## {label} Review\n\n{response.strip()}")
+
+    # Build the output comment
+    if not sections and not all_clear:
+        comment = "<!-- AI review: no personas were triggered -->"
+    elif not sections:
+        # All personas ran clean
+        clear_list = ", ".join(all_clear)
+        comment = f"### AI Review\n\n✅ No concerns found ({clear_list})."
+    else:
+        parts = ["### AI Review\n"]
+        parts.extend(sections)
+        if all_clear:
+            parts.append(f"\n---\n✅ No concerns from: {', '.join(all_clear)}.")
+        comment = "\n\n".join(parts)
+
+    with open("review_comment.txt", "w", encoding="utf-8") as f:
+        f.write(comment)
+
+    print(f"Done. {len(sections)} section(s) with findings, {len(all_clear)} all-clear.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/pr-review.py
+++ b/.github/scripts/pr-review.py
@@ -19,7 +19,6 @@ Environment variables (set by pr-review.yml):
 
 import json
 import os
-import re
 import sys
 import time
 import urllib.request
@@ -209,7 +208,6 @@ def main() -> None:
     if not sections and not all_clear:
         comment = "<!-- AI review: no personas were triggered -->"
     elif not sections:
-        # All personas ran clean
         clear_list = ", ".join(all_clear)
         comment = f"### AI Review\n\n✅ No concerns found ({clear_list})."
     else:

--- a/.github/scripts/pr-review.py
+++ b/.github/scripts/pr-review.py
@@ -19,6 +19,7 @@ Environment variables (set by pr-review.yml):
 
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
@@ -65,6 +66,25 @@ PERSONAS = {
 # Helpers
 # ---------------------------------------------------------------------------
 
+_SENSITIVE_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"(?i)(api[_-]?key\s*[:=]\s*)\S+"), r"\1[REDACTED_API_KEY]"),
+    (re.compile(r"(?i)(secret\s*[:=]\s*)\S+"), r"\1[REDACTED_SECRET]"),
+    (re.compile(r"(?i)(token\s*[:=]\s*)\S+"), r"\1[REDACTED_TOKEN]"),
+    (re.compile(r"(?i)(password\s*[:=]\s*)\S+"), r"\1[REDACTED_PASSWORD]"),
+    (re.compile(r"(?i)(private[_-]?key\s*[:=]\s*)\S+"), r"\1[REDACTED_PRIVATE_KEY]"),
+    (re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----", re.DOTALL), "[REDACTED_PRIVATE_KEY]"),
+    # Long base64-like or hex tokens (32+ chars of [A-Za-z0-9+/=_-])
+    (re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])"), "[REDACTED_TOKEN]"),
+]
+
+
+def sanitize_diff(diff: str) -> str:
+    """Redact common sensitive patterns from a diff before sending to the API."""
+    for pattern, replacement in _SENSITIVE_PATTERNS:
+        diff = pattern.sub(replacement, diff)
+    return diff
+
+
 def read_file(path: str) -> str:
     try:
         with open(path, "r", encoding="utf-8") as f:
@@ -107,6 +127,14 @@ def call_api(api_key: str, model: str, system: str, user: str) -> str | None:
             req = urllib.request.Request(API_URL, data=payload, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=60) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
+                if (
+                    not isinstance(data, dict)
+                    or not isinstance(data.get("content"), list)
+                    or not data["content"]
+                    or not isinstance(data["content"][0], dict)
+                    or not isinstance(data["content"][0].get("text"), str)
+                ):
+                    return None
                 return data["content"][0]["text"]
         except urllib.error.HTTPError as e:
             body = e.read().decode("utf-8", errors="replace")
@@ -123,8 +151,11 @@ def call_api(api_key: str, model: str, system: str, user: str) -> str | None:
 
 
 def is_no_findings(text: str) -> bool:
-    """Heuristic: true when the model reported no concerns."""
-    lower = text.lower().strip()
+    """Heuristic: true when the model reported no concerns.
+
+    Requires one of the no-concern phrases to appear as a standalone sentence
+    with no other substantive content around it.
+    """
     no_concern_phrases = [
         "no gui/ux concerns",
         "no server owner concerns",
@@ -133,7 +164,20 @@ def is_no_findings(text: str) -> bool:
         "no concerns found",
         "nothing to flag",
     ]
-    return any(p in lower for p in no_concern_phrases) and len(text) < 300
+    if len(text) >= 300:
+        return False
+    sentences = [s.strip() for s in re.split(r"[.!?]\s*", text) if s.strip()]
+    for phrase in no_concern_phrases:
+        for sentence in sentences:
+            if sentence.lower() == phrase:
+                # Ensure no other sentence has substantive content
+                others = [s for s in sentences if s.lower() != phrase]
+                if not any(
+                    s and not re.match(r"^(and|but|however|also)\b", s, re.I)
+                    for s in others
+                ):
+                    return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +194,11 @@ def main() -> None:
 
     model = os.environ.get("REVIEW_MODEL", DEFAULT_MODEL)
     diff_file = os.environ.get("DIFF_FILE", "/tmp/pr.diff")
-    max_diff_chars = int(os.environ.get("MAX_DIFF_CHARS", DEFAULT_MAX_DIFF_CHARS))
+    try:
+        max_diff_chars = int(os.environ.get("MAX_DIFF_CHARS", DEFAULT_MAX_DIFF_CHARS))
+    except ValueError:
+        print("WARNING: MAX_DIFF_CHARS is not a valid integer — using default.", file=sys.stderr)
+        max_diff_chars = DEFAULT_MAX_DIFF_CHARS
 
     # Load the diff
     diff = read_file(diff_file)
@@ -191,7 +239,7 @@ def main() -> None:
         )
         user_prompt = (
             "Review the following pull request diff using your persona and checklist.\n\n"
-            "```diff\n" + diff + "\n```"
+            "```diff\n" + sanitize_diff(diff) + "\n```"
         )
 
         response = call_api(api_key, model, system_prompt, user_prompt)

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,27 @@
+name: Java CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew shadowJar

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,97 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+
+jobs:
+  # ------------------------------------------------------------------
+  # Step 1: Detect which domains were touched so we only invoke the
+  # relevant personas. McCore has two: extensibility and testing.
+  # ------------------------------------------------------------------
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      needs_api:  ${{ steps.detect.outputs.api }}
+      needs_test: ${{ steps.detect.outputs.test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: detect
+        name: Detect changed file domains
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          echo "$CHANGED"
+
+          api=false
+          test=false
+
+          while IFS= read -r f; do
+            [[ "$f" =~ src/.*/event/.*\.java ]]    && api=true
+            [[ "$f" =~ src/.*/registry/.*\.java ]] && api=true
+            [[ "$f" =~ src/.*/gui/.*\.java ]]      && api=true
+            [[ "$f" =~ src/.*/database/.*\.java ]] && api=true
+            [[ "$f" =~ src/main/.*\.java ]]        && test=true
+          done <<< "$CHANGED"
+
+          echo "api=$api"   >> "$GITHUB_OUTPUT"
+          echo "test=$test" >> "$GITHUB_OUTPUT"
+
+  # ------------------------------------------------------------------
+  # Step 2: Run the AI personas for each triggered domain.
+  # Skips silently if ANTHROPIC_API_KEY is not configured (fork PRs).
+  # ------------------------------------------------------------------
+  review:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: |
+      needs.detect-changes.outputs.needs_api  == 'true' ||
+      needs.detect-changes.outputs.needs_test == 'true'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate PR diff
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          git diff "$BASE" "$HEAD" > /tmp/pr.diff 2>/dev/null || \
+            git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run AI persona reviews
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REVIEW_MODEL:      ${{ vars.REVIEW_MODEL || 'claude-haiku-4-5-20251001' }}
+          NEEDS_GUI:         "false"
+          NEEDS_CONFIG:      "false"
+          NEEDS_API:         ${{ needs.detect-changes.outputs.needs_api }}
+          NEEDS_TEST:        ${{ needs.detect-changes.outputs.needs_test }}
+          DIFF_FILE:         /tmp/pr.diff
+        run: python3 .github/scripts/pr-review.py
+
+      - name: Post review comment
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' && hashFiles('review_comment.txt') != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat review_comment.txt)
+          if [[ "$BODY" == "<!--"* ]]; then
+            echo "Suppressed comment — not posting."
+            exit 0
+          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,7 @@ jobs:
       needs_api: ${{ steps.detect.outputs.api }}
       needs_test: ${{ steps.detect.outputs.test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
             git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -37,8 +37,8 @@ jobs:
             [[ "$f" =~ src/.*/registry/.*\.java ]] && api=true
             [[ "$f" =~ src/.*/gui/.*\.java ]]      && api=true
             [[ "$f" =~ src/.*/database/.*\.java ]] && api=true
-            [[ "$f" =~ src/.*/.*\.java ]]          && api=true
             [[ "$f" =~ src/test/.*\.java ]]        && test=true
+            [[ "$f" =~ src/.*/.*\.java ]] && [[ ! "$f" =~ src/test/ ]] && api=true
           done <<< "$CHANGED"
 
           echo "api=$api"   >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -37,9 +37,8 @@ jobs:
             [[ "$f" =~ src/.*/registry/.*\.java ]] && api=true
             [[ "$f" =~ src/.*/gui/.*\.java ]]      && api=true
             [[ "$f" =~ src/.*/database/.*\.java ]] && api=true
-            [[ "$f" =~ src/main/.*\.java ]]        && api=true
             [[ "$f" =~ src/.*/.*\.java ]]          && api=true
-            [[ "$f" =~ src/main/.*\.java ]]        && test=true
+            [[ "$f" =~ src/test/.*\.java ]]        && test=true
           done <<< "$CHANGED"
 
           echo "api=$api"   >> "$GITHUB_OUTPUT"
@@ -103,9 +102,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BODY=$(cat review_comment.txt)
-          if [[ "$BODY" == "<!--"* ]]; then
+          if [[ "$(head -c 4 review_comment.txt)" == "<!--" ]]; then
             echo "Suppressed comment — not posting."
             exit 0
           fi
-          gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
+          gh pr comment ${{ github.event.pull_request.number }} --body-file review_comment.txt

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,7 +3,7 @@ name: AI PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main, develop]
+    branches: [master, develop, recode]
 
 jobs:
   # ------------------------------------------------------------------
@@ -13,7 +13,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      needs_api:  ${{ steps.detect.outputs.api }}
+      needs_api: ${{ steps.detect.outputs.api }}
       needs_test: ${{ steps.detect.outputs.test }}
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +37,8 @@ jobs:
             [[ "$f" =~ src/.*/registry/.*\.java ]] && api=true
             [[ "$f" =~ src/.*/gui/.*\.java ]]      && api=true
             [[ "$f" =~ src/.*/database/.*\.java ]] && api=true
+            [[ "$f" =~ src/main/.*\.java ]]        && api=true
+            [[ "$f" =~ src/.*/.*\.java ]]          && api=true
             [[ "$f" =~ src/main/.*\.java ]]        && test=true
           done <<< "$CHANGED"
 
@@ -54,6 +56,7 @@ jobs:
       needs.detect-changes.outputs.needs_api  == 'true' ||
       needs.detect-changes.outputs.needs_test == 'true'
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -87,12 +90,12 @@ jobs:
         if: steps.check-key.outputs.available == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          REVIEW_MODEL:      ${{ vars.REVIEW_MODEL || 'claude-haiku-4-5-20251001' }}
-          NEEDS_GUI:         "false"
-          NEEDS_CONFIG:      "false"
-          NEEDS_API:         ${{ needs.detect-changes.outputs.needs_api }}
-          NEEDS_TEST:        ${{ needs.detect-changes.outputs.needs_test }}
-          DIFF_FILE:         /tmp/pr.diff
+          REVIEW_MODEL: ${{ vars.REVIEW_MODEL || 'claude-haiku-4-5-20251001' }}
+          NEEDS_GUI: "false"
+          NEEDS_CONFIG: "false"
+          NEEDS_API: ${{ needs.detect-changes.outputs.needs_api }}
+          NEEDS_TEST: ${{ needs.detect-changes.outputs.needs_test }}
+          DIFF_FILE: /tmp/pr.diff
         run: python3 .github/scripts/pr-review.py
 
       - name: Post review comment

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -72,8 +72,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Check API key
+        id: check-key
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: Run AI persona reviews
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        if: steps.check-key.outputs.available == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           REVIEW_MODEL:      ${{ vars.REVIEW_MODEL || 'claude-haiku-4-5-20251001' }}
@@ -85,7 +96,7 @@ jobs:
         run: python3 .github/scripts/pr-review.py
 
       - name: Post review comment
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' && hashFiles('review_comment.txt') != '' }}
+        if: steps.check-key.outputs.available == 'true' && hashFiles('review_comment.txt') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,5 +424,8 @@ After any commit or PR that introduces one of the following, **update `CLAUDE.md
 | New coding standard adopted | `CLAUDE.md` Coding Standards section |
 | New GUI pattern added | `CLAUDE.md` + `gui-system.mdc` |
 | New database pattern added | `CLAUDE.md` + `database-system.mdc` |
+| New public API pattern or breaking-change rule | `persona-extensibility.mdc` + `.claude/commands/review-extensibility.md` |
+| New test structural pattern or anti-pattern | `persona-testing.mdc` + `.claude/commands/review-testing.md` |
+| CI review file-pattern for a new domain | `.github/workflows/pr-review.yml` detect-changes step |
 
 These files are the project's living technical contract — stale steering files produce stale AI output.


### PR DESCRIPTION
## Summary

This PR introduces an automated AI-powered code review system for McCore using Anthropic's Claude API, along with developer tooling to support the review process and local development workflow.

## Key Changes

**AI-Powered PR Review System**
- Added `.github/scripts/pr-review.py`: Python script that orchestrates multi-persona AI reviews using the Anthropic Messages API
  - Detects which code domains changed (extensibility, testing) via environment variables
  - Loads domain-specific review personas from `.cursor/rules/` files
  - Calls Claude API with project context (CLAUDE.md) + persona rules + PR diff
  - Implements retry logic with exponential backoff for transient API failures
  - Consolidates findings into a single Markdown comment posted to the PR
  - Gracefully skips if API key is unavailable (e.g., fork PRs)

- Added `.github/workflows/pr-review.yml`: GitHub Actions workflow that:
  - Detects changed file patterns to determine which personas to invoke (API/extensibility, testing)
  - Generates the PR diff and passes it to the review script
  - Posts the consolidated review comment to the PR
  - Only runs on main/develop branches and skips silently if ANTHROPIC_API_KEY is not configured

**Review Personas**
- Added `.cursor/rules/persona-extensibility.mdc`: Third-party extensibility auditor persona
  - Reviews public API contracts, binary compatibility, GUI/database framework changes
  - Checks for extension points, @NotNull/@Nullable consistency, registry stability
  - Ensures McCore remains plugin-agnostic

- Added `.cursor/rules/persona-testing.mdc`: Testing auditor persona
  - Reviews test coverage gaps, MockBukkit usage, TimeProvider patterns
  - Checks for pure-Java vs. Bukkit-dependent separation
  - Validates test naming conventions and fixture organization

**Developer Commands & Tooling**
- Added `.claude/commands/review-extensibility.md`: Manual command to invoke extensibility review persona in Claude Code
- Added `.claude/commands/review-testing.md`: Manual command to invoke testing review persona in Claude Code
- Added `.claude/commands/verify.md`: Command to run `./gradlew shadowJar` and report build/test results
- Added `.claude/settings.json`: Cursor/Claude Code configuration with:
  - Allowed Bash commands (gradle tasks, git operations)
  - PostToolUse hook for incremental compilation checks
- Added `.claude/hooks/post-edit-compile.sh`: Hook that runs `./gradlew compileJava` after Java file edits and surfaces compiler errors immediately

**CI/CD & Code Review Configuration**
- Added `.github/workflows/gradle.yml`: Standard Java CI workflow that builds with Gradle on all branches
- Added `.coderabbit.yaml`: CodeRabbit configuration with McCore-specific review rules
  - Accepts intentional patterns (generics, async scheduling, abstract base classes)
  - Flags plugin-agnostic violations immediately
  - Defers API extension and test structure reviews to dedicated AI personas

**Documentation**
- Updated `CLAUDE.md` with references to new review personas and developer commands

## Notable Implementation Details

- **Selective Persona Invocation**: The workflow detects changed file patterns (e.g., `src/*/event/*.java`, `src/main/*.java`) and only invokes relevant personas, reducing API calls and review latency
- **Graceful Degradation**: If ANTHROPIC_API_KEY is not set, the script writes a suppressed comment and exits cleanly; the workflow does not fail
- **Heuristic Filtering**: The script uses a simple heuristic (`is_no_findings()`) to suppress verbose "no concerns" responses and only post meaningful findings
- **Diff Truncation**: Large diffs are truncated to 30,000 characters (configurable) to stay within API token limits
- **Retry Strategy**: Transient errors (429, 529, network timeouts) are retried with exponential backoff (2s, 4s, 8s); permanent HTTP errors fail fast
- **Incremental Compilation**: The post-edit hook provides immediate feedback to Claude Code when Java compilation fails, enabling faster iteration

https://claude.ai/code/session_01Ckae4mH7sneaYK5xYUmtsd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Java CI that produces shaded build artifacts.
  * Implemented AI-assisted PR review orchestration and a review runner script.
  * Added a post-edit compile hook and project settings to invoke it automatically.
  * Added CI workflow to detect changes and trigger persona-based review jobs.

* **Documentation**
  * Added review personas and checklists for testing and third‑party extensibility.
  * Added verification guidance and updated project guidance and automation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->