### PR TITLE
Add itemName() to CustomItemHook and CustomItemWrapper

### DIFF
--- a/src/main/java/com/diamonddagger590/mccore/external/common/CustomItemHook.java
+++ b/src/main/java/com/diamonddagger590/mccore/external/common/CustomItemHook.java
@@ -1,11 +1,14 @@
 package com.diamonddagger590.mccore.external.common;
 
 import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A type of {@link com.diamonddagger590.mccore.registry.plugin.PluginHook} which supports custom item models.
@@ -66,4 +69,13 @@ public interface CustomItemHook {
      */
     @NotNull
     Optional<Set<String>> itemModels(@NotNull ItemStack itemStack);
+
+    /**
+     * Gets the name to use to represent the {@link CustomItemWrapper}.
+     *
+     * @param customItemWrapper The {@link CustomItemWrapper} to get the name of.
+     * @return The name to use to represent the {@link CustomItemWrapper}.
+     */
+    @NotNull
+    String itemName(@NotNull CustomItemWrapper customItemWrapper);
 }

--- a/src/main/java/com/diamonddagger590/mccore/external/headdatabase/CoreHeadDatabaseHook.java
+++ b/src/main/java/com/diamonddagger590/mccore/external/headdatabase/CoreHeadDatabaseHook.java
@@ -3,12 +3,18 @@ package com.diamonddagger590.mccore.external.headdatabase;
 import com.diamonddagger590.mccore.CorePlugin;
 import com.diamonddagger590.mccore.external.common.CustomItemHook;
 import com.diamonddagger590.mccore.registry.plugin.PluginHook;
+import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The hook needed to support <a href="https://www.spigotmc.org/resources/head-database.14280/">HeadDatabase</a>
@@ -62,5 +68,65 @@ public class CoreHeadDatabaseHook extends PluginHook<CorePlugin> implements Cust
     public Optional<Set<String>> itemModels(@NotNull ItemStack itemStack) {
         String itemID = headDatabaseAPI.getItemID(itemStack);
         return Optional.ofNullable(itemID == null ? null : Set.of(itemID));
+    }
+
+    /**
+     * Gets a player-friendly name for the item represented by the provided {@link CustomItemWrapper}.
+     * <p>
+     * For HeadDatabase custom items, the head is fetched via its ID and the display name is
+     * extracted from the item meta. If no name is found, the head ID is formatted into
+     * title case. For vanilla materials, the material name is similarly title-cased.
+     *
+     * @param customItemWrapper The {@link CustomItemWrapper} to get the name of.
+     * @return The player-friendly name for the item.
+     */
+    @Override
+    @NotNull
+    public String itemName(@NotNull CustomItemWrapper customItemWrapper) {
+        if (customItemWrapper.customItem().isPresent()) {
+            String headId = customItemWrapper.customItem().get();
+            ItemStack head = headDatabaseAPI.getItemHead(headId);
+            if (head != null && head.hasItemMeta()) {
+                ItemMeta meta = head.getItemMeta();
+                if (meta.hasDisplayName()) {
+                    String name = PlainTextComponentSerializer.plainText().serialize(meta.displayName());
+                    if (!name.isEmpty()) {
+                        return name;
+                    }
+                }
+            }
+            return formatItemId(headId);
+        }
+        return formatMaterial(customItemWrapper.material().orElseThrow());
+    }
+
+    /**
+     * Formats a namespaced item ID into a title-cased display string.
+     * The namespace is stripped and underscores are replaced with spaces.
+     *
+     * @param itemId The namespaced item ID to format.
+     * @return A title-cased display string.
+     */
+    @NotNull
+    private static String formatItemId(@NotNull String itemId) {
+        String key = itemId.contains(":") ? itemId.substring(itemId.indexOf(':') + 1) : itemId;
+        return Arrays.stream(key.split("_"))
+            .filter(word -> !word.isEmpty())
+            .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase())
+            .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * Formats a {@link Material} name into a title-cased display string.
+     *
+     * @param material The {@link Material} to format.
+     * @return A title-cased display string.
+     */
+    @NotNull
+    private static String formatMaterial(@NotNull Material material) {
+        return Arrays.stream(material.name().split("_"))
+            .filter(word -> !word.isEmpty())
+            .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase())
+            .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/diamonddagger590/mccore/external/itemsadder/CoreItemsAdderHook.java
+++ b/src/main/java/com/diamonddagger590/mccore/external/itemsadder/CoreItemsAdderHook.java
@@ -5,6 +5,7 @@ import com.diamonddagger590.mccore.external.common.CustomBlockHook;
 import com.diamonddagger590.mccore.external.common.CustomItemHook;
 import com.diamonddagger590.mccore.registry.plugin.PluginHook;
 import com.diamonddagger590.mccore.util.item.CustomBlockWrapper;
+import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
 import dev.lone.itemsadder.api.CustomBlock;
 import dev.lone.itemsadder.api.CustomStack;
 import net.kyori.adventure.text.Component;
@@ -163,6 +164,42 @@ public class CoreItemsAdderHook extends PluginHook<CorePlugin> implements Custom
         } else {
             block.setType(Material.AIR);
         }
+    }
+
+    /**
+     * Gets a player-friendly name for the item represented by the provided {@link CustomItemWrapper}.
+     * <p>
+     * For ItemsAdder custom items, the item name is resolved via {@link CustomStack#itemName()},
+     * falling back to {@link CustomStack#getDisplayName()} (with legacy color codes stripped).
+     * If neither yields a name, the item ID is formatted into
+     * title case (e.g. {@code "my_namespace:cool_item"} → {@code "Cool Item"}).
+     * For vanilla materials, the material name is similarly title-cased.
+     *
+     * @param customItemWrapper The {@link CustomItemWrapper} to get the name of.
+     * @return The player-friendly name for the item.
+     */
+    @Override
+    @NotNull
+    public String itemName(@NotNull CustomItemWrapper customItemWrapper) {
+        if (customItemWrapper.customItem().isPresent()) {
+            String itemId = customItemWrapper.customItem().get();
+            CustomStack customStack = CustomStack.getInstance(itemId);
+            if (customStack != null) {
+                Component nameComponent = customStack.itemName();
+                if (nameComponent != null) {
+                    String name = PlainTextComponentSerializer.plainText().serialize(nameComponent);
+                    if (!name.isEmpty()) {
+                        return name;
+                    }
+                }
+                String legacyName = customStack.getDisplayName();
+                if (legacyName != null && !legacyName.isEmpty()) {
+                    return legacyName.replaceAll("§[0-9a-fklmnorA-FKLMNOR]", "");
+                }
+            }
+            return formatBlockId(itemId);
+        }
+        return formatMaterial(customItemWrapper.material().orElseThrow());
     }
 
     /**

--- a/src/main/java/com/diamonddagger590/mccore/external/nexo/CoreNexoHook.java
+++ b/src/main/java/com/diamonddagger590/mccore/external/nexo/CoreNexoHook.java
@@ -5,6 +5,7 @@ import com.diamonddagger590.mccore.external.common.CustomBlockHook;
 import com.diamonddagger590.mccore.external.common.CustomItemHook;
 import com.diamonddagger590.mccore.registry.plugin.PluginHook;
 import com.diamonddagger590.mccore.util.item.CustomBlockWrapper;
+import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
 import com.nexomc.nexo.api.NexoBlocks;
 import com.nexomc.nexo.api.NexoItems;
 import com.nexomc.nexo.items.ItemBuilder;
@@ -186,6 +187,42 @@ public class CoreNexoHook extends PluginHook<CorePlugin> implements CustomItemHo
                 0.25, 0.25, 0.25,
                 0.05,
                 data);
+    }
+
+    /**
+     * Gets a player-friendly name for the item represented by the provided {@link CustomItemWrapper}.
+     * <p>
+     * For Nexo custom items, the item name is resolved via {@link ItemBuilder#getItemName()}
+     * when set, falling back to {@link ItemBuilder#getCustomName()}. If neither yields a name,
+     * the item ID is formatted into
+     * title case (e.g. {@code "my_namespace:cool_item"} → {@code "Cool Item"}).
+     * For vanilla materials, the material name is similarly title-cased.
+     *
+     * @param customItemWrapper The {@link CustomItemWrapper} to get the name of.
+     * @return The player-friendly name for the item.
+     */
+    @Override
+    @NotNull
+    public String itemName(@NotNull CustomItemWrapper customItemWrapper) {
+        if (customItemWrapper.customItem().isPresent()) {
+            String itemId = customItemWrapper.customItem().get();
+            if (isItem(itemId)) {
+                ItemBuilder nexoItem = NexoItems.itemFromId(itemId);
+                if (nexoItem != null) {
+                    Component nameComponent = Boolean.TRUE.equals(nexoItem.hasItemName())
+                        ? nexoItem.getItemName()
+                        : nexoItem.getCustomName();
+                    if (nameComponent != null) {
+                        String name = PlainTextComponentSerializer.plainText().serialize(nameComponent);
+                        if (!name.isEmpty()) {
+                            return name;
+                        }
+                    }
+                }
+            }
+            return formatBlockId(itemId);
+        }
+        return formatMaterial(customItemWrapper.material().orElseThrow());
     }
 
     /**

--- a/src/main/java/com/diamonddagger590/mccore/util/item/CustomItemWrapper.java
+++ b/src/main/java/com/diamonddagger590/mccore/util/item/CustomItemWrapper.java
@@ -111,6 +111,33 @@ public class CustomItemWrapper {
     }
 
     /**
+     * Returns a player-friendly display name for this item as a MiniMessage string.
+     * <p>
+     * For vanilla materials this returns a MiniMessage {@code <lang:key>} tag (e.g.
+     * {@code <lang:item.minecraft.iron_ingot>}), which the Minecraft client resolves to the
+     * item's localized name in the player's own language.
+     * <p>
+     * For custom items the name is resolved via the registered {@link CustomItemHook}, falling
+     * back to {@code "Missing Item"} if no hook recognises the custom item identifier.
+     *
+     * @return A MiniMessage string representing the display name of this item.
+     */
+    @NotNull
+    public String itemName() {
+        if (customItem != null) {
+            List<CustomItemHook> pluginHooks = RegistryAccess.registryAccess().registry(RegistryKey.PLUGIN_HOOK).pluginHooks(CustomItemHook.class);
+            for (CustomItemHook hook : pluginHooks) {
+                if (hook.isItem(customItem)) {
+                    return hook.itemName(this);
+                }
+            }
+            return "Missing Item";
+        } else {
+            return "<lang:" + material.translationKey() + ">";
+        }
+    }
+
+    /**
      * Checks to see if the provided {@link Material} equals this wrapper.
      *
      * @param material The material to check.


### PR DESCRIPTION
## Summary
- Add `itemName(CustomItemWrapper)` to `CustomItemHook` interface, mirroring the existing `blockName(CustomBlockWrapper)` on `CustomBlockHook`
- Add `itemName()` convenience method on `CustomItemWrapper` that delegates to registered hooks, mirroring `CustomBlockWrapper.blockName()`
- Implement `itemName()` in all three `CustomItemHook` implementations: `CoreNexoHook`, `CoreItemsAdderHook`, and `CoreHeadDatabaseHook`

## Motivation

McRPG's `recode` branch has 18 call sites across quest objective types (`ConsumeItemObjectiveType`, `EnchantItemObjectiveType`, `SmithingObjectiveType`, `CraftItemObjectiveType`, `VillagerTradeObjectiveType`, `FishCatchObjectiveType`, `AnvilRepairObjectiveType`, `ItemPickupObjectiveType`) that call `CustomItemWrapper.itemName()` for localization placeholders, but the method did not exist in McCore. This caused compilation failures.

## Implementation Details

Each hook's `itemName()` follows the same resolution strategy as its `blockName()` counterpart:

- **Nexo**: Prefers `ItemBuilder.getItemName()` (ITEM_NAME), falls back to `getCustomName()` (CUSTOM_NAME), then title-cases the item ID
- **ItemsAdder**: Prefers `CustomStack.itemName()` (Adventure Component), falls back to `getDisplayName()` with legacy color stripping, then title-cases the item ID
- **HeadDatabase**: Extracts display name from the head's `ItemMeta`, falls back to title-casing the head ID

For vanilla materials, `CustomItemWrapper.itemName()` returns a MiniMessage `<lang:key>` tag (e.g. `<lang:item.minecraft.iron_ingot>`) for client-side localization.

## Test plan
- [x] McCore compiles successfully
- [x] All existing McCore tests pass
- [ ] Verify McRPG recode compiles after publishing this to Maven local
- [ ] Manual verification on a running server with Nexo/ItemsAdder custom items

https://claude.ai/code/session_01Nn9zVR1ZpL8YxtifxB6hnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn9zVR1ZpL8YxtifxB6hnr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented standardized item naming system providing player-friendly display names for custom items across HeadDatabase, ItemsAdder, and Nexo plugins.
  * Custom items now show formatted display names with intelligent fallback to formatted identifiers.
  * Vanilla materials display localized names in the standardized format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->