### PR TITLE
[Tests] Add unit tests for Parser, Pair, LinkedNode, ChainComparator, ChainFilter

### DIFF
--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -61,6 +61,20 @@ Built-in `CoreManagerKey` constants: `CORE_GUI_MANAGER`, `CORE_PLAYER_MANAGER`, 
 
 - `@NotNull` (IntelliJ v12) on all non-null return types and parameters
 - `@Override` on all overridden methods
+- `@DisplayName` on every test method — human-readable Given/When/Then sentence
+
+## Test Naming Convention
+
+Every test method must follow the Given/When/Then pattern:
+
+- **Method name:** `methodUnderTest_expectedOutcome_whenCondition` (descriptive, snake_case segments)
+- **@DisplayName:** `"Given [precondition], when [action], then [expected outcome]"`
+
+```java
+@Test
+@DisplayName("Given a registered statistic, when getting by key, then returns the statistic")
+void getStatistic_returnsStatistic_whenKeyIsRegistered() { ... }
+```
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,27 @@ Caffeine is shadowed and relocated to `com.diamonddagger590.mccore.caffeine` in 
 - Use `RegistryResetExtension` / `InternalResetTestTools` where available to reset singleton state between tests
 - There are no integration tests — server behavior is validated manually on a running Paper server
 
+### Test Naming Convention
+
+Every test method **must** follow the Given/When/Then naming pattern and carry a `@DisplayName` annotation:
+
+- **Method name:** `methodUnderTest_expectedOutcome_whenCondition` (descriptive, snake_case segments)
+- **@DisplayName:** `"Given [precondition], when [action], then [expected outcome]"` — a full human-readable sentence
+
+```java
+@Test
+@DisplayName("Given a registered statistic, when getting by key, then returns the statistic")
+void getStatistic_returnsStatistic_whenKeyIsRegistered() { ... }
+
+@Test
+@DisplayName("Given an uninitialized variable with error mode, when evaluating, then throws EvaluationException")
+void getValue_throwsEvaluationException_whenVariableUninitializedAndErrorModeEnabled() { ... }
+```
+
+- Test methods must be `public` or package-private (not `private`)
+- Every test method must have at least one assertion
+- Tests that do not need Bukkit APIs must be plain JUnit tests — do not spin up MockBukkit unnecessarily
+
 ---
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ McCore is a Java 21 Paper plugin framework library that provides shared infrastr
 | Command | Description |
 |---------|-------------|
 | `./gradlew shadowJar` | Build shaded jar **(recommended)** |
-| `./gradlew test` | Run tests only |
+| `./gradlew test` | Run tests only (automatically generates JaCoCo coverage report) |
+| `./gradlew jacocoTestReport` | Generate coverage report (HTML at `build/reports/jacoco/test/html/index.html`, XML at `build/reports/jacoco/test/jacocoTestReport.xml`) |
 | `./gradlew publishToMavenLocal` | Publish snapshot to local Maven cache for downstream consumption |
 | `./gradlew build` | Compile + shadowJar |
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `java-library`
     `java-test-fixtures`
     `maven-publish`
+    jacoco
     id("io.github.goooler.shadow") version "8.1.7"
 }
 
@@ -125,6 +126,16 @@ tasks {
 
     test {
         useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
+    }
+
+    jacocoTestReport {
+        dependsOn(test)
+        reports {
+            xml.required.set(true)
+            html.required.set(true)
+            csv.required.set(false)
+        }
     }
 
     shadowJar {

--- a/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
@@ -1,0 +1,151 @@
+package com.diamonddagger590.mccore.pair;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class PairTest {
+
+    @Test
+    void immutablePairOfCreatesWithCorrectValues() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("hello", 42);
+        assertEquals("hello", pair.getLeft());
+        assertEquals(42, pair.getRight());
+    }
+
+    @Test
+    void mutablePairOfCreatesWithCorrectValues() {
+        MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
+        assertEquals("hello", pair.getLeft());
+        assertEquals(42, pair.getRight());
+    }
+
+    @Test
+    void mutablePairSetLeftUpdatesValue() {
+        MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
+        pair.setLeft("world");
+        assertEquals("world", pair.getLeft());
+        assertEquals(42, pair.getRight());
+    }
+
+    @Test
+    void mutablePairSetRightUpdatesValue() {
+        MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
+        pair.setRight(99);
+        assertEquals("hello", pair.getLeft());
+        assertEquals(99, pair.getRight());
+    }
+
+    @Test
+    void mutablePairBothSidesUpdatable() {
+        MutablePair<String, String> pair = MutablePair.of("a", "b");
+        pair.setLeft("x");
+        pair.setRight("y");
+        assertEquals("x", pair.getLeft());
+        assertEquals("y", pair.getRight());
+    }
+
+    @Test
+    void equalPairsAreEqual() {
+        ImmutablePair<String, Integer> pair1 = ImmutablePair.of("test", 1);
+        ImmutablePair<String, Integer> pair2 = ImmutablePair.of("test", 1);
+        assertEquals(pair1, pair2);
+    }
+
+    @Test
+    void differentLeftsAreNotEqual() {
+        ImmutablePair<String, Integer> pair1 = ImmutablePair.of("a", 1);
+        ImmutablePair<String, Integer> pair2 = ImmutablePair.of("b", 1);
+        assertNotEquals(pair1, pair2);
+    }
+
+    @Test
+    void differentRightsAreNotEqual() {
+        ImmutablePair<String, Integer> pair1 = ImmutablePair.of("a", 1);
+        ImmutablePair<String, Integer> pair2 = ImmutablePair.of("a", 2);
+        assertNotEquals(pair1, pair2);
+    }
+
+    @Test
+    void equalPairsHaveSameHashCode() {
+        ImmutablePair<String, Integer> pair1 = ImmutablePair.of("test", 42);
+        ImmutablePair<String, Integer> pair2 = ImmutablePair.of("test", 42);
+        assertEquals(pair1.hashCode(), pair2.hashCode());
+    }
+
+    @Test
+    void pairEqualsSelf() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("self", 1);
+        assertEquals(pair, pair);
+    }
+
+    @Test
+    void pairNotEqualToNull() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
+        assertNotEquals(null, pair);
+    }
+
+    @Test
+    void pairNotEqualToDifferentType() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
+        assertNotEquals("not a pair", pair);
+    }
+
+    @Test
+    void immutableAndMutableWithSameValuesAreEqual() {
+        ImmutablePair<String, Integer> immutable = ImmutablePair.of("test", 1);
+        MutablePair<String, Integer> mutable = MutablePair.of("test", 1);
+        assertEquals(immutable, mutable);
+        assertEquals(mutable, immutable);
+    }
+
+    @Test
+    void toStringContainsClassName() {
+        ImmutablePair<String, Integer> immutable = ImmutablePair.of("a", 1);
+        assertTrue(immutable.toString().contains("ImmutablePair"));
+        assertTrue(immutable.toString().contains("a"));
+        assertTrue(immutable.toString().contains("1"));
+
+        MutablePair<String, Integer> mutable = MutablePair.of("b", 2);
+        assertTrue(mutable.toString().contains("MutablePair"));
+        assertTrue(mutable.toString().contains("b"));
+        assertTrue(mutable.toString().contains("2"));
+    }
+
+    @Test
+    void toStringFormatIsCorrect() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("left", 42);
+        assertEquals("ImmutablePair(left;42)", pair.toString());
+    }
+
+    @Test
+    void mutablePairToStringReflectsUpdatedValues() {
+        MutablePair<String, Integer> pair = MutablePair.of("old", 1);
+        pair.setLeft("new");
+        pair.setRight(2);
+        assertEquals("MutablePair(new;2)", pair.toString());
+    }
+
+    @Test
+    void pairsWithDifferentGenericTypes() {
+        ImmutablePair<Integer, Double> pair = ImmutablePair.of(1, 2.5);
+        assertEquals(1, pair.getLeft());
+        assertEquals(2.5, pair.getRight());
+    }
+
+    @Test
+    void mutablePairEqualityAfterMutation() {
+        MutablePair<String, Integer> pair1 = MutablePair.of("a", 1);
+        MutablePair<String, Integer> pair2 = MutablePair.of("b", 2);
+        assertNotEquals(pair1, pair2);
+
+        pair2.setLeft("a");
+        pair2.setRight(1);
+        assertEquals(pair1, pair2);
+    }
+
+    private static void assertTrue(boolean condition) {
+        org.junit.jupiter.api.Assertions.assertTrue(condition);
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
@@ -1,28 +1,33 @@
 package com.diamonddagger590.mccore.pair;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PairTest {
 
     @Test
-    void immutablePairOfCreatesWithCorrectValues() {
+    @DisplayName("Given left and right values, when creating ImmutablePair, then stores both values correctly")
+    void of_storesBothValues_whenCreatingImmutablePair() {
         ImmutablePair<String, Integer> pair = ImmutablePair.of("hello", 42);
         assertEquals("hello", pair.getLeft());
         assertEquals(42, pair.getRight());
     }
 
     @Test
-    void mutablePairOfCreatesWithCorrectValues() {
+    @DisplayName("Given left and right values, when creating MutablePair, then stores both values correctly")
+    void of_storesBothValues_whenCreatingMutablePair() {
         MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
         assertEquals("hello", pair.getLeft());
         assertEquals(42, pair.getRight());
     }
 
     @Test
-    void mutablePairSetLeftUpdatesValue() {
+    @DisplayName("Given a MutablePair, when setting left value, then left updates and right is unchanged")
+    void setLeft_updatesLeftOnly_whenCalled() {
         MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
         pair.setLeft("world");
         assertEquals("world", pair.getLeft());
@@ -30,7 +35,8 @@ class PairTest {
     }
 
     @Test
-    void mutablePairSetRightUpdatesValue() {
+    @DisplayName("Given a MutablePair, when setting right value, then right updates and left is unchanged")
+    void setRight_updatesRightOnly_whenCalled() {
         MutablePair<String, Integer> pair = MutablePair.of("hello", 42);
         pair.setRight(99);
         assertEquals("hello", pair.getLeft());
@@ -38,7 +44,8 @@ class PairTest {
     }
 
     @Test
-    void mutablePairBothSidesUpdatable() {
+    @DisplayName("Given a MutablePair, when setting both sides, then both values update")
+    void setLeftAndRight_updatesBothSides_whenBothCalled() {
         MutablePair<String, String> pair = MutablePair.of("a", "b");
         pair.setLeft("x");
         pair.setRight("y");
@@ -47,53 +54,61 @@ class PairTest {
     }
 
     @Test
-    void equalPairsAreEqual() {
+    @DisplayName("Given two pairs with equal values, when comparing, then they are equal")
+    void equals_returnsTrue_whenBothSidesMatch() {
         ImmutablePair<String, Integer> pair1 = ImmutablePair.of("test", 1);
         ImmutablePair<String, Integer> pair2 = ImmutablePair.of("test", 1);
         assertEquals(pair1, pair2);
     }
 
     @Test
-    void differentLeftsAreNotEqual() {
+    @DisplayName("Given two pairs with different left values, when comparing, then they are not equal")
+    void equals_returnsFalse_whenLeftValuesDiffer() {
         ImmutablePair<String, Integer> pair1 = ImmutablePair.of("a", 1);
         ImmutablePair<String, Integer> pair2 = ImmutablePair.of("b", 1);
         assertNotEquals(pair1, pair2);
     }
 
     @Test
-    void differentRightsAreNotEqual() {
+    @DisplayName("Given two pairs with different right values, when comparing, then they are not equal")
+    void equals_returnsFalse_whenRightValuesDiffer() {
         ImmutablePair<String, Integer> pair1 = ImmutablePair.of("a", 1);
         ImmutablePair<String, Integer> pair2 = ImmutablePair.of("a", 2);
         assertNotEquals(pair1, pair2);
     }
 
     @Test
-    void equalPairsHaveSameHashCode() {
+    @DisplayName("Given two equal pairs, when computing hash codes, then hash codes are equal")
+    void hashCode_isEqual_whenPairsAreEqual() {
         ImmutablePair<String, Integer> pair1 = ImmutablePair.of("test", 42);
         ImmutablePair<String, Integer> pair2 = ImmutablePair.of("test", 42);
         assertEquals(pair1.hashCode(), pair2.hashCode());
     }
 
     @Test
-    void pairEqualsSelf() {
+    @DisplayName("Given a pair, when compared to itself, then returns equal")
+    void equals_returnsTrue_whenComparedToSelf() {
         ImmutablePair<String, Integer> pair = ImmutablePair.of("self", 1);
         assertEquals(pair, pair);
     }
 
     @Test
-    void pairNotEqualToNull() {
+    @DisplayName("Given a pair, when compared to null, then returns not equal")
+    void equals_returnsFalse_whenComparedToNull() {
         ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
         assertNotEquals(null, pair);
     }
 
     @Test
-    void pairNotEqualToDifferentType() {
+    @DisplayName("Given a pair, when compared to a non-Pair object, then returns not equal")
+    void equals_returnsFalse_whenComparedToDifferentType() {
         ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
         assertNotEquals("not a pair", pair);
     }
 
     @Test
-    void immutableAndMutableWithSameValuesAreEqual() {
+    @DisplayName("Given an ImmutablePair and MutablePair with same values, when comparing, then they are equal")
+    void equals_returnsTrue_whenImmutableAndMutableHaveSameValues() {
         ImmutablePair<String, Integer> immutable = ImmutablePair.of("test", 1);
         MutablePair<String, Integer> mutable = MutablePair.of("test", 1);
         assertEquals(immutable, mutable);
@@ -101,26 +116,15 @@ class PairTest {
     }
 
     @Test
-    void toStringContainsClassName() {
-        ImmutablePair<String, Integer> immutable = ImmutablePair.of("a", 1);
-        assertTrue(immutable.toString().contains("ImmutablePair"));
-        assertTrue(immutable.toString().contains("a"));
-        assertTrue(immutable.toString().contains("1"));
-
-        MutablePair<String, Integer> mutable = MutablePair.of("b", 2);
-        assertTrue(mutable.toString().contains("MutablePair"));
-        assertTrue(mutable.toString().contains("b"));
-        assertTrue(mutable.toString().contains("2"));
-    }
-
-    @Test
-    void toStringFormatIsCorrect() {
+    @DisplayName("Given an ImmutablePair, when calling toString, then includes class name and values")
+    void toString_containsClassNameAndValues_whenCalledOnImmutablePair() {
         ImmutablePair<String, Integer> pair = ImmutablePair.of("left", 42);
         assertEquals("ImmutablePair(left;42)", pair.toString());
     }
 
     @Test
-    void mutablePairToStringReflectsUpdatedValues() {
+    @DisplayName("Given a MutablePair with updated values, when calling toString, then reflects new values")
+    void toString_reflectsUpdatedValues_whenMutablePairMutated() {
         MutablePair<String, Integer> pair = MutablePair.of("old", 1);
         pair.setLeft("new");
         pair.setRight(2);
@@ -128,14 +132,8 @@ class PairTest {
     }
 
     @Test
-    void pairsWithDifferentGenericTypes() {
-        ImmutablePair<Integer, Double> pair = ImmutablePair.of(1, 2.5);
-        assertEquals(1, pair.getLeft());
-        assertEquals(2.5, pair.getRight());
-    }
-
-    @Test
-    void mutablePairEqualityAfterMutation() {
+    @DisplayName("Given two MutablePairs with initially different values, when mutated to match, then they are equal")
+    void equals_returnsTrue_whenMutablePairMutatedToMatch() {
         MutablePair<String, Integer> pair1 = MutablePair.of("a", 1);
         MutablePair<String, Integer> pair2 = MutablePair.of("b", 2);
         assertNotEquals(pair1, pair2);
@@ -143,9 +141,5 @@ class PairTest {
         pair2.setLeft("a");
         pair2.setRight(1);
         assertEquals(pair1, pair2);
-    }
-
-    private static void assertTrue(boolean condition) {
-        org.junit.jupiter.api.Assertions.assertTrue(condition);
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
@@ -1,12 +1,10 @@
 package com.diamonddagger590.mccore.parser;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.HashSet;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,173 +14,233 @@ class ParserTest {
 
     private static final double DELTA = 1e-9;
 
-    @ParameterizedTest
-    @CsvSource({
-        "2+3, 5.0",
-        "10-4, 6.0",
-        "3*7, 21.0",
-        "20/4, 5.0",
-        "10%3, 1.0",
-        "2^10, 1024.0"
-    })
-    void basicArithmeticOperators(String expression, double expected) {
-        Parser parser = new Parser(expression);
-        assertEquals(expected, parser.getValue(), DELTA);
+    @Test
+    @DisplayName("Given addition expression, when evaluating, then returns correct sum")
+    void getValue_returnsSum_whenExpressionIsAddition() {
+        assertEquals(5.0, new Parser("2+3").getValue(), DELTA);
     }
 
     @Test
-    void operatorPrecedenceMultiplicationBeforeAddition() {
-        Parser parser = new Parser("2+3*4");
-        assertEquals(14.0, parser.getValue(), DELTA);
+    @DisplayName("Given subtraction expression, when evaluating, then returns correct difference")
+    void getValue_returnsDifference_whenExpressionIsSubtraction() {
+        assertEquals(6.0, new Parser("10-4").getValue(), DELTA);
     }
 
     @Test
-    void operatorPrecedenceDivisionBeforeSubtraction() {
-        Parser parser = new Parser("10-6/2");
-        assertEquals(7.0, parser.getValue(), DELTA);
+    @DisplayName("Given multiplication expression, when evaluating, then returns correct product")
+    void getValue_returnsProduct_whenExpressionIsMultiplication() {
+        assertEquals(21.0, new Parser("3*7").getValue(), DELTA);
     }
 
     @Test
-    void parenthesesOverridePrecedence() {
-        Parser parser = new Parser("(2+3)*4");
-        assertEquals(20.0, parser.getValue(), DELTA);
+    @DisplayName("Given division expression, when evaluating, then returns correct quotient")
+    void getValue_returnsQuotient_whenExpressionIsDivision() {
+        assertEquals(5.0, new Parser("20/4").getValue(), DELTA);
     }
 
     @Test
-    void nestedParentheses() {
-        Parser parser = new Parser("((2+3)*(4-1))");
-        assertEquals(15.0, parser.getValue(), DELTA);
+    @DisplayName("Given modulo expression, when evaluating, then returns correct remainder")
+    void getValue_returnsRemainder_whenExpressionIsModulo() {
+        assertEquals(1.0, new Parser("10%3").getValue(), DELTA);
     }
 
     @Test
-    void unaryNegation() {
-        Parser parser = new Parser("-5");
-        assertEquals(-5.0, parser.getValue(), DELTA);
+    @DisplayName("Given exponentiation expression, when evaluating, then returns correct power")
+    void getValue_returnsPower_whenExpressionIsExponentiation() {
+        assertEquals(1024.0, new Parser("2^10").getValue(), DELTA);
     }
 
     @Test
-    void unaryNegationInExpression() {
-        Parser parser = new Parser("3*-2");
-        assertEquals(-6.0, parser.getValue(), DELTA);
+    @DisplayName("Given mixed addition and multiplication, when evaluating, then multiplication takes precedence")
+    void getValue_appliesMultiplicationFirst_whenMixedWithAddition() {
+        assertEquals(14.0, new Parser("2+3*4").getValue(), DELTA);
     }
 
     @Test
-    void exponentiation() {
-        Parser parser = new Parser("2^3^2");
-        assertEquals(512.0, parser.getValue(), DELTA);
+    @DisplayName("Given mixed subtraction and division, when evaluating, then division takes precedence")
+    void getValue_appliesDivisionFirst_whenMixedWithSubtraction() {
+        assertEquals(7.0, new Parser("10-6/2").getValue(), DELTA);
     }
 
     @Test
-    void decimalNumbers() {
-        Parser parser = new Parser("1.5+2.5");
-        assertEquals(4.0, parser.getValue(), DELTA);
+    @DisplayName("Given parenthesized sub-expression, when evaluating, then parentheses override precedence")
+    void getValue_overridesPrecedence_whenParenthesesPresent() {
+        assertEquals(20.0, new Parser("(2+3)*4").getValue(), DELTA);
     }
 
     @Test
-    void scientificNotation() {
-        Parser parser = new Parser("1e3+500");
-        assertEquals(1500.0, parser.getValue(), DELTA);
+    @DisplayName("Given nested parentheses, when evaluating, then inner parentheses evaluate first")
+    void getValue_evaluatesInnerFirst_whenParenthesesAreNested() {
+        assertEquals(15.0, new Parser("((2+3)*(4-1))").getValue(), DELTA);
     }
 
     @Test
-    void scientificNotationNegativeExponent() {
-        Parser parser = new Parser("5e-2");
-        assertEquals(0.05, parser.getValue(), DELTA);
+    @DisplayName("Given unary negation, when evaluating, then returns negative value")
+    void getValue_returnsNegative_whenUnaryNegationApplied() {
+        assertEquals(-5.0, new Parser("-5").getValue(), DELTA);
     }
 
     @Test
-    void builtInConstantPi() {
-        Parser parser = new Parser("pi");
-        assertEquals(Math.PI, parser.getValue(), DELTA);
+    @DisplayName("Given unary negation in multiplication, when evaluating, then negation applies correctly")
+    void getValue_appliesNegation_whenUsedInMultiplication() {
+        assertEquals(-6.0, new Parser("3*-2").getValue(), DELTA);
     }
 
     @Test
-    void builtInConstantE() {
-        Parser parser = new Parser("e");
-        assertEquals(Math.E, parser.getValue(), DELTA);
+    @DisplayName("Given right-associative exponentiation, when evaluating, then evaluates right-to-left")
+    void getValue_evaluatesRightToLeft_whenExponentiationChained() {
+        assertEquals(512.0, new Parser("2^3^2").getValue(), DELTA);
     }
 
     @Test
-    void piInExpression() {
-        Parser parser = new Parser("2*pi");
-        assertEquals(2 * Math.PI, parser.getValue(), DELTA);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "sin(0), 0.0",
-        "cos(0), 1.0",
-        "abs(-5), 5.0",
-        "sqrt(16), 4.0",
-        "exp(0), 1.0",
-        "ln(1), 0.0",
-        "log(100), 2.0",
-    })
-    void builtInFunctions(String expression, double expected) {
-        Parser parser = new Parser(expression);
-        assertEquals(expected, parser.getValue(), DELTA);
+    @DisplayName("Given decimal numbers, when evaluating, then handles fractional values correctly")
+    void getValue_handlesFractions_whenDecimalNumbersUsed() {
+        assertEquals(4.0, new Parser("1.5+2.5").getValue(), DELTA);
     }
 
     @Test
-    void sinOfPiIsZero() {
-        Parser parser = new Parser("sin(pi)");
-        assertEquals(0.0, parser.getValue(), 1e-6);
+    @DisplayName("Given scientific notation with positive exponent, when evaluating, then parses correctly")
+    void getValue_parsesScientificNotation_whenPositiveExponent() {
+        assertEquals(1500.0, new Parser("1e3+500").getValue(), DELTA);
     }
 
     @Test
-    void cosOfPiIsNegativeOne() {
-        Parser parser = new Parser("cos(pi)");
-        assertEquals(-1.0, parser.getValue(), DELTA);
+    @DisplayName("Given scientific notation with negative exponent, when evaluating, then parses correctly")
+    void getValue_parsesScientificNotation_whenNegativeExponent() {
+        assertEquals(0.05, new Parser("5e-2").getValue(), DELTA);
     }
 
     @Test
-    void tanOfZero() {
-        Parser parser = new Parser("tan(0)");
-        assertEquals(0.0, parser.getValue(), DELTA);
+    @DisplayName("Given built-in constant pi, when evaluating, then returns Math.PI")
+    void getValue_returnsMathPI_whenExpressionIsPi() {
+        assertEquals(Math.PI, new Parser("pi").getValue(), DELTA);
     }
 
     @Test
-    void asinAndAcos() {
-        Parser parser1 = new Parser("asin(1)");
-        assertEquals(Math.PI / 2, parser1.getValue(), DELTA);
-
-        Parser parser2 = new Parser("acos(1)");
-        assertEquals(0.0, parser2.getValue(), DELTA);
+    @DisplayName("Given built-in constant e, when evaluating, then returns Math.E")
+    void getValue_returnsMathE_whenExpressionIsE() {
+        assertEquals(Math.E, new Parser("e").getValue(), DELTA);
     }
 
     @Test
-    void atanOfZero() {
-        Parser parser = new Parser("atan(0)");
-        assertEquals(0.0, parser.getValue(), DELTA);
+    @DisplayName("Given pi in a multiplication, when evaluating, then applies arithmetic to constant")
+    void getValue_multipliesConstant_whenPiUsedInExpression() {
+        assertEquals(2 * Math.PI, new Parser("2*pi").getValue(), DELTA);
     }
 
     @Test
-    void sinhCoshTanh() {
-        Parser sinhParser = new Parser("sinh(0)");
-        assertEquals(0.0, sinhParser.getValue(), DELTA);
-
-        Parser coshParser = new Parser("cosh(0)");
-        assertEquals(1.0, coshParser.getValue(), DELTA);
-
-        Parser tanhParser = new Parser("tanh(0)");
-        assertEquals(0.0, tanhParser.getValue(), DELTA);
+    @DisplayName("Given sin(0), when evaluating, then returns zero")
+    void getValue_returnsZero_whenSinOfZero() {
+        assertEquals(0.0, new Parser("sin(0)").getValue(), DELTA);
     }
 
     @Test
-    void nestedFunctions() {
-        Parser parser = new Parser("abs(sin(0))");
-        assertEquals(0.0, parser.getValue(), DELTA);
+    @DisplayName("Given cos(0), when evaluating, then returns one")
+    void getValue_returnsOne_whenCosOfZero() {
+        assertEquals(1.0, new Parser("cos(0)").getValue(), DELTA);
     }
 
     @Test
-    void variableSubstitution() {
+    @DisplayName("Given abs(-5), when evaluating, then returns positive value")
+    void getValue_returnsPositive_whenAbsOfNegative() {
+        assertEquals(5.0, new Parser("abs(-5)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given sqrt(16), when evaluating, then returns correct square root")
+    void getValue_returnsSquareRoot_whenSqrtCalled() {
+        assertEquals(4.0, new Parser("sqrt(16)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given exp(0), when evaluating, then returns one")
+    void getValue_returnsOne_whenExpOfZero() {
+        assertEquals(1.0, new Parser("exp(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given ln(1), when evaluating, then returns zero")
+    void getValue_returnsZero_whenLnOfOne() {
+        assertEquals(0.0, new Parser("ln(1)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given log(100), when evaluating, then returns two")
+    void getValue_returnsTwo_whenLogOfHundred() {
+        assertEquals(2.0, new Parser("log(100)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given sin(pi), when evaluating, then returns approximately zero")
+    void getValue_returnsApproximatelyZero_whenSinOfPi() {
+        assertEquals(0.0, new Parser("sin(pi)").getValue(), 1e-6);
+    }
+
+    @Test
+    @DisplayName("Given cos(pi), when evaluating, then returns negative one")
+    void getValue_returnsNegativeOne_whenCosOfPi() {
+        assertEquals(-1.0, new Parser("cos(pi)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given tan(0), when evaluating, then returns zero")
+    void getValue_returnsZero_whenTanOfZero() {
+        assertEquals(0.0, new Parser("tan(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given asin(1), when evaluating, then returns pi/2")
+    void getValue_returnsPiOverTwo_whenAsinOfOne() {
+        assertEquals(Math.PI / 2, new Parser("asin(1)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given acos(1), when evaluating, then returns zero")
+    void getValue_returnsZero_whenAcosOfOne() {
+        assertEquals(0.0, new Parser("acos(1)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given atan(0), when evaluating, then returns zero")
+    void getValue_returnsZero_whenAtanOfZero() {
+        assertEquals(0.0, new Parser("atan(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given sinh(0), when evaluating, then returns zero")
+    void getValue_returnsZero_whenSinhOfZero() {
+        assertEquals(0.0, new Parser("sinh(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given cosh(0), when evaluating, then returns one")
+    void getValue_returnsOne_whenCoshOfZero() {
+        assertEquals(1.0, new Parser("cosh(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given tanh(0), when evaluating, then returns zero")
+    void getValue_returnsZero_whenTanhOfZero() {
+        assertEquals(0.0, new Parser("tanh(0)").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given nested functions, when evaluating, then inner function evaluates first")
+    void getValue_evaluatesInnerFunctionFirst_whenFunctionsAreNested() {
+        assertEquals(0.0, new Parser("abs(sin(0))").getValue(), DELTA);
+    }
+
+    @Test
+    @DisplayName("Given a variable set to 5, when evaluating x+1, then returns 6")
+    void getValue_returnsSum_whenVariableIsSet() {
         Parser parser = new Parser("x+1");
         parser.setVariable("x", 5.0);
         assertEquals(6.0, parser.getValue(), DELTA);
     }
 
     @Test
-    void multipleVariables() {
+    @DisplayName("Given multiple variables, when evaluating compound expression, then substitutes all")
+    void getValue_substitutesAllVariables_whenMultipleVariablesSet() {
         Parser parser = new Parser("x*y+z");
         parser.setVariable("x", 2.0);
         parser.setVariable("y", 3.0);
@@ -191,44 +249,46 @@ class ParserTest {
     }
 
     @Test
-    void variableDefaultsToZeroWhenErrorIsFalse() {
-        Parser parser = new Parser("x+1", false);
-        assertEquals(1.0, parser.getValue(), DELTA);
+    @DisplayName("Given uninitialized variable with error=false, when evaluating, then defaults to zero")
+    void getValue_defaultsToZero_whenVariableUninitializedAndErrorDisabled() {
+        assertEquals(1.0, new Parser("x+1", false).getValue(), DELTA);
     }
 
     @Test
-    void uninitializedVariableThrowsWhenErrorIsTrue() {
+    @DisplayName("Given uninitialized variable with error=true, when evaluating, then throws EvaluationException")
+    void getValue_throwsEvaluationException_whenVariableUninitializedAndErrorEnabled() {
         Parser parser = new Parser("x+1", true);
         assertThrows(EvaluationException.class, parser::getValue);
     }
 
     @Test
-    void variableReassignment() {
+    @DisplayName("Given a variable reassigned to a new value, when evaluating, then uses the new value")
+    void getValue_usesNewValue_whenVariableReassigned() {
         Parser parser = new Parser("x*2");
         parser.setVariable("x", 3.0);
         assertEquals(6.0, parser.getValue(), DELTA);
-
         parser.setVariable("x", 10.0);
         assertEquals(20.0, parser.getValue(), DELTA);
     }
 
     @Test
-    void implicitMultiplicationConstantTimesVariable() {
+    @DisplayName("Given a constant followed by a variable, when parsing, then detects implicit multiplication")
+    void getValue_appliesImplicitMultiplication_whenConstantPrecedesVariable() {
         Parser parser = new Parser("2x");
         parser.setVariable("x", 5.0);
         assertEquals(10.0, parser.getValue(), DELTA);
     }
 
     @Test
-    void implicitMultiplicationConstantTimesFunction() {
-        Parser parser = new Parser("2sqrt(4)");
-        assertEquals(4.0, parser.getValue(), DELTA);
+    @DisplayName("Given a constant followed by a function, when parsing, then detects implicit multiplication")
+    void getValue_appliesImplicitMultiplication_whenConstantPrecedesFunction() {
+        assertEquals(4.0, new Parser("2sqrt(4)").getValue(), DELTA);
     }
 
     @Test
-    void getParsedVariablesReturnsAllVariables() {
-        Parser parser = new Parser("x+y*z");
-        HashSet<String> vars = parser.getParsedVariables();
+    @DisplayName("Given expression with three variables, when getting parsed variables, then returns all three")
+    void getParsedVariables_returnsAllVariables_whenExpressionContainsThree() {
+        HashSet<String> vars = new Parser("x+y*z").getParsedVariables();
         assertEquals(3, vars.size());
         assertTrue(vars.contains("x"));
         assertTrue(vars.contains("y"));
@@ -236,54 +296,55 @@ class ParserTest {
     }
 
     @Test
-    void getParsedFunctionsReturnsUsedFunctions() {
-        Parser parser = new Parser("sin(x)+cos(y)");
-        HashSet<String> funcs = parser.getParsedFunctions();
+    @DisplayName("Given expression with sin and cos, when getting parsed functions, then returns both")
+    void getParsedFunctions_returnsBoth_whenExpressionUsesSinAndCos() {
+        HashSet<String> funcs = new Parser("sin(x)+cos(y)").getParsedFunctions();
         assertEquals(2, funcs.size());
         assertTrue(funcs.contains("sin"));
         assertTrue(funcs.contains("cos"));
     }
 
     @Test
-    void getExpressionReturnsNormalizedString() {
-        Parser parser = new Parser("2+3");
-        String expression = parser.getExpression();
-        assertFalse(expression.isEmpty());
+    @DisplayName("Given a valid expression, when getting expression string, then returns non-empty string")
+    void getExpression_returnsNonEmpty_whenExpressionIsValid() {
+        assertFalse(new Parser("2+3").getExpression().isEmpty());
     }
 
     @Test
-    void getInputStringStripsInvalidCharacters() {
-        Parser parser = new Parser("2 + 3");
-        assertEquals("2+3", parser.getInputString());
+    @DisplayName("Given input with spaces, when getting input string, then spaces are stripped")
+    void getInputString_stripsSpaces_whenInputContainsWhitespace() {
+        assertEquals("2+3", new Parser("2 + 3").getInputString());
     }
 
     @Test
-    void complexExpression() {
-        Parser parser = new Parser("(3+2)^2 - sqrt(16) * 2 + abs(-10)");
-        assertEquals(27.0, parser.getValue(), DELTA);
+    @DisplayName("Given a complex mixed expression, when evaluating, then returns correct result")
+    void getValue_returnsCorrectResult_whenExpressionIsMixedAndComplex() {
+        assertEquals(27.0, new Parser("(3+2)^2 - sqrt(16) * 2 + abs(-10)").getValue(), DELTA);
     }
 
     @Test
-    void divisionByZeroReturnsInfinity() {
-        Parser parser = new Parser("1/0");
-        assertEquals(Double.POSITIVE_INFINITY, parser.getValue());
+    @DisplayName("Given division by zero, when evaluating, then returns positive infinity")
+    void getValue_returnsInfinity_whenDividingByZero() {
+        assertEquals(Double.POSITIVE_INFINITY, new Parser("1/0").getValue());
     }
 
     @Test
-    void moduloOperator() {
-        Parser parser = new Parser("17%5");
-        assertEquals(2.0, parser.getValue(), DELTA);
+    @DisplayName("Given modulo expression 17%5, when evaluating, then returns 2")
+    void getValue_returnsRemainder_whenModuloApplied() {
+        assertEquals(2.0, new Parser("17%5").getValue(), DELTA);
     }
 
     @Test
-    void multipleGetValueReturnsSameResult() {
+    @DisplayName("Given already-evaluated parser, when evaluating again, then returns same result")
+    void getValue_returnsSameResult_whenCalledMultipleTimes() {
         Parser parser = new Parser("2+3");
         assertEquals(5.0, parser.getValue(), DELTA);
         assertEquals(5.0, parser.getValue(), DELTA);
     }
 
     @Test
-    void getTreeReturnsSameTreeOnMultipleCalls() {
+    @DisplayName("Given already-parsed tree, when getting tree again, then returns same instance")
+    void getTree_returnsSameInstance_whenCalledMultipleTimes() {
         Parser parser = new Parser("2+3");
         ExpressionNode tree1 = parser.getTree();
         ExpressionNode tree2 = parser.getTree();
@@ -291,37 +352,38 @@ class ParserTest {
     }
 
     @Test
-    void unmatchedOpenParenthesisThrowsParseError() {
-        Parser parser = new Parser("(2+3");
-        assertThrows(ParseError.class, parser::getValue);
+    @DisplayName("Given unmatched open parenthesis, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenOpenParenthesisUnmatched() {
+        assertThrows(ParseError.class, () -> new Parser("(2+3").getValue());
     }
 
     @Test
-    void functionMissingParenthesisThrowsParseError() {
-        Parser parser = new Parser("sin 5");
-        assertThrows(ParseError.class, parser::getValue);
+    @DisplayName("Given function without parenthesis, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenFunctionMissingParenthesis() {
+        assertThrows(ParseError.class, () -> new Parser("sin 5").getValue());
     }
 
     @Test
-    void emptyExpressionThrowsParseError() {
-        Parser parser = new Parser("");
-        assertThrows(ParseError.class, parser::getValue);
+    @DisplayName("Given empty expression, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenExpressionIsEmpty() {
+        assertThrows(ParseError.class, () -> new Parser("").getValue());
     }
 
     @Test
-    void log2Function() {
-        Parser parser = new Parser("log2(8)");
-        assertEquals(3.0, parser.getValue(), DELTA);
+    @DisplayName("Given log2(8), when evaluating, then returns 3")
+    void getValue_returnsThree_whenLog2Of8() {
+        assertEquals(3.0, new Parser("log2(8)").getValue(), DELTA);
     }
 
     @Test
-    void expFunction() {
-        Parser parser = new Parser("exp(1)");
-        assertEquals(Math.E, parser.getValue(), DELTA);
+    @DisplayName("Given exp(1), when evaluating, then returns Math.E")
+    void getValue_returnsMathE_whenExpOfOne() {
+        assertEquals(Math.E, new Parser("exp(1)").getValue(), DELTA);
     }
 
     @Test
-    void longVariableNames() {
+    @DisplayName("Given long variable names with underscores, when evaluating, then resolves correctly")
+    void getValue_resolvesCorrectly_whenVariableNamesAreLongWithUnderscores() {
         Parser parser = new Parser("level * base_damage + armor_bonus");
         parser.setVariable("level", 10.0);
         parser.setVariable("base_damage", 5.0);
@@ -330,20 +392,20 @@ class ParserTest {
     }
 
     @Test
-    void chainedAddition() {
-        Parser parser = new Parser("1+2+3+4+5");
-        assertEquals(15.0, parser.getValue(), DELTA);
+    @DisplayName("Given chained additions, when evaluating, then sums all terms")
+    void getValue_sumsAllTerms_whenAdditionsAreChained() {
+        assertEquals(15.0, new Parser("1+2+3+4+5").getValue(), DELTA);
     }
 
     @Test
-    void chainedMultiplication() {
-        Parser parser = new Parser("2*3*4");
-        assertEquals(24.0, parser.getValue(), DELTA);
+    @DisplayName("Given chained multiplications, when evaluating, then multiplies all factors")
+    void getValue_multipliesAllFactors_whenMultiplicationsAreChained() {
+        assertEquals(24.0, new Parser("2*3*4").getValue(), DELTA);
     }
 
     @Test
-    void mixedOperatorsComplexPrecedence() {
-        Parser parser = new Parser("2+3*4-6/2+1");
-        assertEquals(12.0, parser.getValue(), DELTA);
+    @DisplayName("Given mixed operators, when evaluating, then applies correct precedence throughout")
+    void getValue_appliesCorrectPrecedence_whenOperatorsAreMixed() {
+        assertEquals(12.0, new Parser("2+3*4-6/2+1").getValue(), DELTA);
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
@@ -1,0 +1,349 @@
+package com.diamonddagger590.mccore.parser;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParserTest {
+
+    private static final double DELTA = 1e-9;
+
+    @ParameterizedTest
+    @CsvSource({
+        "2+3, 5.0",
+        "10-4, 6.0",
+        "3*7, 21.0",
+        "20/4, 5.0",
+        "10%3, 1.0",
+        "2^10, 1024.0"
+    })
+    void basicArithmeticOperators(String expression, double expected) {
+        Parser parser = new Parser(expression);
+        assertEquals(expected, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void operatorPrecedenceMultiplicationBeforeAddition() {
+        Parser parser = new Parser("2+3*4");
+        assertEquals(14.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void operatorPrecedenceDivisionBeforeSubtraction() {
+        Parser parser = new Parser("10-6/2");
+        assertEquals(7.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void parenthesesOverridePrecedence() {
+        Parser parser = new Parser("(2+3)*4");
+        assertEquals(20.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void nestedParentheses() {
+        Parser parser = new Parser("((2+3)*(4-1))");
+        assertEquals(15.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void unaryNegation() {
+        Parser parser = new Parser("-5");
+        assertEquals(-5.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void unaryNegationInExpression() {
+        Parser parser = new Parser("3*-2");
+        assertEquals(-6.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void exponentiation() {
+        Parser parser = new Parser("2^3^2");
+        assertEquals(512.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void decimalNumbers() {
+        Parser parser = new Parser("1.5+2.5");
+        assertEquals(4.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void scientificNotation() {
+        Parser parser = new Parser("1e3+500");
+        assertEquals(1500.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void scientificNotationNegativeExponent() {
+        Parser parser = new Parser("5e-2");
+        assertEquals(0.05, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void builtInConstantPi() {
+        Parser parser = new Parser("pi");
+        assertEquals(Math.PI, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void builtInConstantE() {
+        Parser parser = new Parser("e");
+        assertEquals(Math.E, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void piInExpression() {
+        Parser parser = new Parser("2*pi");
+        assertEquals(2 * Math.PI, parser.getValue(), DELTA);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "sin(0), 0.0",
+        "cos(0), 1.0",
+        "abs(-5), 5.0",
+        "sqrt(16), 4.0",
+        "exp(0), 1.0",
+        "ln(1), 0.0",
+        "log(100), 2.0",
+    })
+    void builtInFunctions(String expression, double expected) {
+        Parser parser = new Parser(expression);
+        assertEquals(expected, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void sinOfPiIsZero() {
+        Parser parser = new Parser("sin(pi)");
+        assertEquals(0.0, parser.getValue(), 1e-6);
+    }
+
+    @Test
+    void cosOfPiIsNegativeOne() {
+        Parser parser = new Parser("cos(pi)");
+        assertEquals(-1.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void tanOfZero() {
+        Parser parser = new Parser("tan(0)");
+        assertEquals(0.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void asinAndAcos() {
+        Parser parser1 = new Parser("asin(1)");
+        assertEquals(Math.PI / 2, parser1.getValue(), DELTA);
+
+        Parser parser2 = new Parser("acos(1)");
+        assertEquals(0.0, parser2.getValue(), DELTA);
+    }
+
+    @Test
+    void atanOfZero() {
+        Parser parser = new Parser("atan(0)");
+        assertEquals(0.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void sinhCoshTanh() {
+        Parser sinhParser = new Parser("sinh(0)");
+        assertEquals(0.0, sinhParser.getValue(), DELTA);
+
+        Parser coshParser = new Parser("cosh(0)");
+        assertEquals(1.0, coshParser.getValue(), DELTA);
+
+        Parser tanhParser = new Parser("tanh(0)");
+        assertEquals(0.0, tanhParser.getValue(), DELTA);
+    }
+
+    @Test
+    void nestedFunctions() {
+        Parser parser = new Parser("abs(sin(0))");
+        assertEquals(0.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void variableSubstitution() {
+        Parser parser = new Parser("x+1");
+        parser.setVariable("x", 5.0);
+        assertEquals(6.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void multipleVariables() {
+        Parser parser = new Parser("x*y+z");
+        parser.setVariable("x", 2.0);
+        parser.setVariable("y", 3.0);
+        parser.setVariable("z", 4.0);
+        assertEquals(10.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void variableDefaultsToZeroWhenErrorIsFalse() {
+        Parser parser = new Parser("x+1", false);
+        assertEquals(1.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void uninitializedVariableThrowsWhenErrorIsTrue() {
+        Parser parser = new Parser("x+1", true);
+        assertThrows(EvaluationException.class, parser::getValue);
+    }
+
+    @Test
+    void variableReassignment() {
+        Parser parser = new Parser("x*2");
+        parser.setVariable("x", 3.0);
+        assertEquals(6.0, parser.getValue(), DELTA);
+
+        parser.setVariable("x", 10.0);
+        assertEquals(20.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void implicitMultiplicationConstantTimesVariable() {
+        Parser parser = new Parser("2x");
+        parser.setVariable("x", 5.0);
+        assertEquals(10.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void implicitMultiplicationConstantTimesFunction() {
+        Parser parser = new Parser("2sqrt(4)");
+        assertEquals(4.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void getParsedVariablesReturnsAllVariables() {
+        Parser parser = new Parser("x+y*z");
+        HashSet<String> vars = parser.getParsedVariables();
+        assertEquals(3, vars.size());
+        assertTrue(vars.contains("x"));
+        assertTrue(vars.contains("y"));
+        assertTrue(vars.contains("z"));
+    }
+
+    @Test
+    void getParsedFunctionsReturnsUsedFunctions() {
+        Parser parser = new Parser("sin(x)+cos(y)");
+        HashSet<String> funcs = parser.getParsedFunctions();
+        assertEquals(2, funcs.size());
+        assertTrue(funcs.contains("sin"));
+        assertTrue(funcs.contains("cos"));
+    }
+
+    @Test
+    void getExpressionReturnsNormalizedString() {
+        Parser parser = new Parser("2+3");
+        String expression = parser.getExpression();
+        assertFalse(expression.isEmpty());
+    }
+
+    @Test
+    void getInputStringStripsInvalidCharacters() {
+        Parser parser = new Parser("2 + 3");
+        assertEquals("2+3", parser.getInputString());
+    }
+
+    @Test
+    void complexExpression() {
+        Parser parser = new Parser("(3+2)^2 - sqrt(16) * 2 + abs(-10)");
+        assertEquals(27.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void divisionByZeroReturnsInfinity() {
+        Parser parser = new Parser("1/0");
+        assertEquals(Double.POSITIVE_INFINITY, parser.getValue());
+    }
+
+    @Test
+    void moduloOperator() {
+        Parser parser = new Parser("17%5");
+        assertEquals(2.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void multipleGetValueReturnsSameResult() {
+        Parser parser = new Parser("2+3");
+        assertEquals(5.0, parser.getValue(), DELTA);
+        assertEquals(5.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void getTreeReturnsSameTreeOnMultipleCalls() {
+        Parser parser = new Parser("2+3");
+        ExpressionNode tree1 = parser.getTree();
+        ExpressionNode tree2 = parser.getTree();
+        assertEquals(tree1, tree2);
+    }
+
+    @Test
+    void unmatchedOpenParenthesisThrowsParseError() {
+        Parser parser = new Parser("(2+3");
+        assertThrows(ParseError.class, parser::getValue);
+    }
+
+    @Test
+    void functionMissingParenthesisThrowsParseError() {
+        Parser parser = new Parser("sin 5");
+        assertThrows(ParseError.class, parser::getValue);
+    }
+
+    @Test
+    void emptyExpressionThrowsParseError() {
+        Parser parser = new Parser("");
+        assertThrows(ParseError.class, parser::getValue);
+    }
+
+    @Test
+    void log2Function() {
+        Parser parser = new Parser("log2(8)");
+        assertEquals(3.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void expFunction() {
+        Parser parser = new Parser("exp(1)");
+        assertEquals(Math.E, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void longVariableNames() {
+        Parser parser = new Parser("level * base_damage + armor_bonus");
+        parser.setVariable("level", 10.0);
+        parser.setVariable("base_damage", 5.0);
+        parser.setVariable("armor_bonus", 3.0);
+        assertEquals(53.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void chainedAddition() {
+        Parser parser = new Parser("1+2+3+4+5");
+        assertEquals(15.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void chainedMultiplication() {
+        Parser parser = new Parser("2*3*4");
+        assertEquals(24.0, parser.getValue(), DELTA);
+    }
+
+    @Test
+    void mixedOperatorsComplexPrecedence() {
+        Parser parser = new Parser("2+3*4-6/2+1");
+        assertEquals(12.0, parser.getValue(), DELTA);
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/LinkedNodeTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/LinkedNodeTest.java
@@ -1,5 +1,6 @@
 package com.diamonddagger590.mccore.util;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,25 +11,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LinkedNodeTest {
 
     @Test
-    void singleNodeHoldsValue() {
+    @DisplayName("Given a single-arg constructor, when getting value, then returns the stored value")
+    void getNodeValue_returnsStoredValue_whenSingleArgConstructorUsed() {
         LinkedNode<String> node = new LinkedNode<>("hello");
         assertEquals("hello", node.getNodeValue());
     }
 
     @Test
-    void singleNodeHasNoNext() {
+    @DisplayName("Given a single node with no next, when checking hasNext, then returns false")
+    void hasNext_returnsFalse_whenNodeHasNoNext() {
         LinkedNode<Integer> node = new LinkedNode<>(42);
         assertFalse(node.hasNext());
     }
 
     @Test
-    void getNextNodeOnSingleNodeThrowsNullPointerException() {
+    @DisplayName("Given a single node with no next, when getting next node, then throws NullPointerException")
+    void getNextNode_throwsNullPointerException_whenNoNextNodeExists() {
         LinkedNode<String> node = new LinkedNode<>("only");
         assertThrows(NullPointerException.class, node::getNextNode);
     }
 
     @Test
-    void constructorWithNextNodeLinksCorrectly() {
+    @DisplayName("Given two-arg constructor with next node, when getting next, then returns the linked node")
+    void getNextNode_returnsLinkedNode_whenTwoArgConstructorUsed() {
         LinkedNode<String> second = new LinkedNode<>("second");
         LinkedNode<String> first = new LinkedNode<>("first", second);
 
@@ -38,7 +43,8 @@ class LinkedNodeTest {
     }
 
     @Test
-    void setNextLinksNodes() {
+    @DisplayName("Given a node with no next, when calling setNext, then hasNext returns true and getNextNode returns the set node")
+    void setNext_linksNodes_whenCalledOnUnlinkedNode() {
         LinkedNode<Integer> first = new LinkedNode<>(1);
         LinkedNode<Integer> second = new LinkedNode<>(2);
 
@@ -49,7 +55,8 @@ class LinkedNodeTest {
     }
 
     @Test
-    void chainOfThreeNodes() {
+    @DisplayName("Given a chain of three nodes, when traversing, then visits all nodes in order")
+    void getNextNode_traversesChain_whenThreeNodesLinked() {
         LinkedNode<String> third = new LinkedNode<>("c");
         LinkedNode<String> second = new LinkedNode<>("b", third);
         LinkedNode<String> first = new LinkedNode<>("a", second);
@@ -61,7 +68,8 @@ class LinkedNodeTest {
     }
 
     @Test
-    void setNextOverridesPreviousLink() {
+    @DisplayName("Given a node with an existing next, when setNext is called with a different node, then overrides the previous link")
+    void setNext_overridesPreviousLink_whenCalledAgain() {
         LinkedNode<Integer> first = new LinkedNode<>(1);
         LinkedNode<Integer> oldNext = new LinkedNode<>(2);
         LinkedNode<Integer> newNext = new LinkedNode<>(3);
@@ -74,16 +82,18 @@ class LinkedNodeTest {
     }
 
     @Test
-    void nodeWithDifferentTypes() {
-        LinkedNode<Double> node = new LinkedNode<>(3.14);
-        assertEquals(3.14, node.getNodeValue());
+    @DisplayName("Given nodes of different generic types, when getting values, then returns correct typed values")
+    void getNodeValue_returnsCorrectType_whenDifferentGenericTypesUsed() {
+        LinkedNode<Double> doubleNode = new LinkedNode<>(3.14);
+        assertEquals(3.14, doubleNode.getNodeValue());
 
         LinkedNode<Boolean> boolNode = new LinkedNode<>(true);
         assertEquals(true, boolNode.getNodeValue());
     }
 
     @Test
-    void traverseLinkedChain() {
+    @DisplayName("Given a linked chain of three nodes, when summing all values via traversal, then returns correct total")
+    void traversal_sumsAllValues_whenChainIsTraversed() {
         LinkedNode<Integer> node3 = new LinkedNode<>(30);
         LinkedNode<Integer> node2 = new LinkedNode<>(20, node3);
         LinkedNode<Integer> node1 = new LinkedNode<>(10, node2);
@@ -99,7 +109,8 @@ class LinkedNodeTest {
     }
 
     @Test
-    void nullPointerExceptionMessageContainsNodeValue() {
+    @DisplayName("Given a node with no next, when NullPointerException is thrown, then message contains the node value")
+    void getNextNode_includesNodeValueInMessage_whenExceptionThrown() {
         LinkedNode<String> node = new LinkedNode<>("myValue");
         NullPointerException exception = assertThrows(NullPointerException.class, node::getNextNode);
         assertTrue(exception.getMessage().contains("myValue"));

--- a/src/test/java/com/diamonddagger590/mccore/util/LinkedNodeTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/LinkedNodeTest.java
@@ -1,0 +1,107 @@
+package com.diamonddagger590.mccore.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LinkedNodeTest {
+
+    @Test
+    void singleNodeHoldsValue() {
+        LinkedNode<String> node = new LinkedNode<>("hello");
+        assertEquals("hello", node.getNodeValue());
+    }
+
+    @Test
+    void singleNodeHasNoNext() {
+        LinkedNode<Integer> node = new LinkedNode<>(42);
+        assertFalse(node.hasNext());
+    }
+
+    @Test
+    void getNextNodeOnSingleNodeThrowsNullPointerException() {
+        LinkedNode<String> node = new LinkedNode<>("only");
+        assertThrows(NullPointerException.class, node::getNextNode);
+    }
+
+    @Test
+    void constructorWithNextNodeLinksCorrectly() {
+        LinkedNode<String> second = new LinkedNode<>("second");
+        LinkedNode<String> first = new LinkedNode<>("first", second);
+
+        assertTrue(first.hasNext());
+        assertEquals(second, first.getNextNode());
+        assertEquals("second", first.getNextNode().getNodeValue());
+    }
+
+    @Test
+    void setNextLinksNodes() {
+        LinkedNode<Integer> first = new LinkedNode<>(1);
+        LinkedNode<Integer> second = new LinkedNode<>(2);
+
+        assertFalse(first.hasNext());
+        first.setNext(second);
+        assertTrue(first.hasNext());
+        assertEquals(second, first.getNextNode());
+    }
+
+    @Test
+    void chainOfThreeNodes() {
+        LinkedNode<String> third = new LinkedNode<>("c");
+        LinkedNode<String> second = new LinkedNode<>("b", third);
+        LinkedNode<String> first = new LinkedNode<>("a", second);
+
+        assertEquals("a", first.getNodeValue());
+        assertEquals("b", first.getNextNode().getNodeValue());
+        assertEquals("c", first.getNextNode().getNextNode().getNodeValue());
+        assertFalse(first.getNextNode().getNextNode().hasNext());
+    }
+
+    @Test
+    void setNextOverridesPreviousLink() {
+        LinkedNode<Integer> first = new LinkedNode<>(1);
+        LinkedNode<Integer> oldNext = new LinkedNode<>(2);
+        LinkedNode<Integer> newNext = new LinkedNode<>(3);
+
+        first.setNext(oldNext);
+        assertEquals(2, first.getNextNode().getNodeValue());
+
+        first.setNext(newNext);
+        assertEquals(3, first.getNextNode().getNodeValue());
+    }
+
+    @Test
+    void nodeWithDifferentTypes() {
+        LinkedNode<Double> node = new LinkedNode<>(3.14);
+        assertEquals(3.14, node.getNodeValue());
+
+        LinkedNode<Boolean> boolNode = new LinkedNode<>(true);
+        assertEquals(true, boolNode.getNodeValue());
+    }
+
+    @Test
+    void traverseLinkedChain() {
+        LinkedNode<Integer> node3 = new LinkedNode<>(30);
+        LinkedNode<Integer> node2 = new LinkedNode<>(20, node3);
+        LinkedNode<Integer> node1 = new LinkedNode<>(10, node2);
+
+        int sum = 0;
+        LinkedNode<Integer> current = node1;
+        sum += current.getNodeValue();
+        while (current.hasNext()) {
+            current = current.getNextNode();
+            sum += current.getNodeValue();
+        }
+        assertEquals(60, sum);
+    }
+
+    @Test
+    void nullPointerExceptionMessageContainsNodeValue() {
+        LinkedNode<String> node = new LinkedNode<>("myValue");
+        NullPointerException exception = assertThrows(NullPointerException.class, node::getNextNode);
+        assertTrue(exception.getMessage().contains("myValue"));
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/comparator/ChainComparatorTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/comparator/ChainComparatorTest.java
@@ -1,0 +1,92 @@
+package com.diamonddagger590.mccore.util.comparator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChainComparatorTest {
+
+    @Test
+    void singleComparatorDelegatesToIt() {
+        ChainComparator<Integer> chain = new ChainComparator<>(Comparator.naturalOrder());
+        assertTrue(chain.compare(1, 2) < 0);
+        assertTrue(chain.compare(2, 1) > 0);
+        assertEquals(0, chain.compare(5, 5));
+    }
+
+    @Test
+    void firstComparatorBreaksTie() {
+        Comparator<String> byLength = Comparator.comparingInt(String::length);
+        Comparator<String> alphabetical = Comparator.naturalOrder();
+
+        ChainComparator<String> chain = new ChainComparator<>(byLength, alphabetical);
+
+        assertTrue(chain.compare("a", "bb") < 0);
+        assertTrue(chain.compare("bb", "a") > 0);
+    }
+
+    @Test
+    void secondComparatorUsedWhenFirstTies() {
+        Comparator<String> byLength = Comparator.comparingInt(String::length);
+        Comparator<String> alphabetical = Comparator.naturalOrder();
+
+        ChainComparator<String> chain = new ChainComparator<>(byLength, alphabetical);
+
+        assertTrue(chain.compare("ab", "ba") < 0);
+        assertTrue(chain.compare("ba", "ab") > 0);
+    }
+
+    @Test
+    void returnsZeroWhenAllComparatorsReturnZero() {
+        Comparator<Integer> alwaysZero1 = (a, b) -> 0;
+        Comparator<Integer> alwaysZero2 = (a, b) -> 0;
+
+        ChainComparator<Integer> chain = new ChainComparator<>(alwaysZero1, alwaysZero2);
+        assertEquals(0, chain.compare(1, 2));
+    }
+
+    @Test
+    void sortsListCorrectlyWithChain() {
+        Comparator<String> byLength = Comparator.comparingInt(String::length);
+        Comparator<String> alphabetical = Comparator.naturalOrder();
+
+        ChainComparator<String> chain = new ChainComparator<>(byLength, alphabetical);
+
+        List<String> list = new ArrayList<>(List.of("bb", "a", "ba", "c", "ab"));
+        list.sort(chain);
+
+        assertEquals(List.of("a", "c", "ab", "ba", "bb"), list);
+    }
+
+    @Test
+    void threeComparatorChain() {
+        record Person(String first, String last, int age) {}
+
+        Comparator<Person> byLast = Comparator.comparing(Person::last);
+        Comparator<Person> byFirst = Comparator.comparing(Person::first);
+        Comparator<Person> byAge = Comparator.comparingInt(Person::age);
+
+        ChainComparator<Person> chain = new ChainComparator<>(byLast, byFirst, byAge);
+
+        Person alice30 = new Person("Alice", "Smith", 30);
+        Person alice25 = new Person("Alice", "Smith", 25);
+        Person bob30 = new Person("Bob", "Smith", 30);
+
+        assertTrue(chain.compare(alice30, bob30) < 0);
+        assertTrue(chain.compare(alice25, alice30) < 0);
+    }
+
+    @Test
+    void reverseComparatorInChain() {
+        Comparator<Integer> descending = Comparator.reverseOrder();
+        ChainComparator<Integer> chain = new ChainComparator<>(descending);
+
+        assertTrue(chain.compare(1, 2) > 0);
+        assertTrue(chain.compare(2, 1) < 0);
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/comparator/ChainComparatorTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/comparator/ChainComparatorTest.java
@@ -1,5 +1,6 @@
 package com.diamonddagger590.mccore.util.comparator;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -12,7 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ChainComparatorTest {
 
     @Test
-    void singleComparatorDelegatesToIt() {
+    @DisplayName("Given a single comparator, when comparing, then delegates to that comparator")
+    void compare_delegatesToSingleComparator_whenOnlyOneProvided() {
         ChainComparator<Integer> chain = new ChainComparator<>(Comparator.naturalOrder());
         assertTrue(chain.compare(1, 2) < 0);
         assertTrue(chain.compare(2, 1) > 0);
@@ -20,7 +22,8 @@ class ChainComparatorTest {
     }
 
     @Test
-    void firstComparatorBreaksTie() {
+    @DisplayName("Given two comparators where the first differentiates, when comparing, then first comparator decides")
+    void compare_usesFirstComparator_whenFirstComparatorDifferentiates() {
         Comparator<String> byLength = Comparator.comparingInt(String::length);
         Comparator<String> alphabetical = Comparator.naturalOrder();
 
@@ -31,7 +34,8 @@ class ChainComparatorTest {
     }
 
     @Test
-    void secondComparatorUsedWhenFirstTies() {
+    @DisplayName("Given two comparators where the first ties, when comparing, then second comparator breaks tie")
+    void compare_usesSecondComparator_whenFirstComparatorTies() {
         Comparator<String> byLength = Comparator.comparingInt(String::length);
         Comparator<String> alphabetical = Comparator.naturalOrder();
 
@@ -42,7 +46,8 @@ class ChainComparatorTest {
     }
 
     @Test
-    void returnsZeroWhenAllComparatorsReturnZero() {
+    @DisplayName("Given all comparators return zero, when comparing, then returns zero")
+    void compare_returnsZero_whenAllComparatorsReturnZero() {
         Comparator<Integer> alwaysZero1 = (a, b) -> 0;
         Comparator<Integer> alwaysZero2 = (a, b) -> 0;
 
@@ -51,7 +56,8 @@ class ChainComparatorTest {
     }
 
     @Test
-    void sortsListCorrectlyWithChain() {
+    @DisplayName("Given a chain of length-then-alpha comparators, when sorting a list, then sorts by length first and alphabetically within same length")
+    void compare_sortsCorrectly_whenUsedToSortList() {
         Comparator<String> byLength = Comparator.comparingInt(String::length);
         Comparator<String> alphabetical = Comparator.naturalOrder();
 
@@ -64,7 +70,8 @@ class ChainComparatorTest {
     }
 
     @Test
-    void threeComparatorChain() {
+    @DisplayName("Given three comparators for last/first/age, when comparing people with same last and first names, then age breaks tie")
+    void compare_usesThirdComparator_whenFirstTwoTie() {
         record Person(String first, String last, int age) {}
 
         Comparator<Person> byLast = Comparator.comparing(Person::last);
@@ -82,9 +89,9 @@ class ChainComparatorTest {
     }
 
     @Test
-    void reverseComparatorInChain() {
-        Comparator<Integer> descending = Comparator.reverseOrder();
-        ChainComparator<Integer> chain = new ChainComparator<>(descending);
+    @DisplayName("Given a reverse-order comparator in the chain, when comparing, then orders descending")
+    void compare_ordersDescending_whenReverseComparatorUsed() {
+        ChainComparator<Integer> chain = new ChainComparator<>(Comparator.reverseOrder());
 
         assertTrue(chain.compare(1, 2) > 0);
         assertTrue(chain.compare(2, 1) < 0);

--- a/src/test/java/com/diamonddagger590/mccore/util/filter/ChainFilterTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/filter/ChainFilterTest.java
@@ -1,5 +1,6 @@
 package com.diamonddagger590.mccore.util.filter;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -13,7 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ChainFilterTest {
 
     @Test
-    void singleFilterApplied() {
+    @DisplayName("Given a single evens-only filter, when filtering a list, then returns only even numbers")
+    void filter_returnsEvenNumbers_whenSingleEvensFilterApplied() {
         Filter<Integer> evensOnly = collection ->
                 collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
 
@@ -24,7 +26,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void multipleFiltersAppliedInOrder() {
+    @DisplayName("Given evens-only then greater-than-three filters, when filtering, then returns even numbers greater than three")
+    void filter_appliesBothFilters_whenTwoFiltersChained() {
         Filter<Integer> evensOnly = collection ->
                 collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
 
@@ -38,7 +41,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void filterOrderMatters() {
+    @DisplayName("Given two filters in different orders, when filtering same input, then produces different results")
+    void filter_producesDifferentResults_whenFilterOrderDiffers() {
         Filter<String> takeFirstTwo = collection ->
                 collection.stream().limit(2).collect(Collectors.toList());
 
@@ -58,7 +62,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void emptyInputReturnsEmpty() {
+    @DisplayName("Given an empty input collection, when filtering, then returns empty collection")
+    void filter_returnsEmpty_whenInputIsEmpty() {
         Filter<Integer> evensOnly = collection ->
                 collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
 
@@ -69,7 +74,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void filterThatRemovesAllReturnsEmpty() {
+    @DisplayName("Given a filter that rejects all elements, when filtering, then returns empty collection")
+    void filter_returnsEmpty_whenFilterRejectsAll() {
         Filter<Integer> removeAll = collection ->
                 collection.stream().filter(n -> false).collect(Collectors.toList());
 
@@ -80,7 +86,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void identityFilterReturnsAllElements() {
+    @DisplayName("Given an identity filter, when filtering, then returns all original elements")
+    void filter_returnsAllElements_whenIdentityFilterUsed() {
         Filter<String> identity = collection -> collection;
 
         ChainFilter<String> chain = new ChainFilter<>(identity);
@@ -91,7 +98,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void threeFiltersChained() {
+    @DisplayName("Given three chained filters (non-negative, even, less-than-ten), when filtering, then all three conditions apply")
+    void filter_appliesAllThreeConditions_whenThreeFiltersChained() {
         Filter<Integer> removeNegatives = collection ->
                 collection.stream().filter(n -> n >= 0).collect(Collectors.toList());
 
@@ -109,7 +117,8 @@ class ChainFilterTest {
     }
 
     @Test
-    void stringFilterChain() {
+    @DisplayName("Given non-empty and starts-with-a filters, when filtering strings, then returns only non-empty strings starting with 'a'")
+    void filter_returnsMatchingStrings_whenStringFiltersChained() {
         Filter<String> nonEmpty = collection ->
                 collection.stream().filter(s -> !s.isEmpty()).collect(Collectors.toList());
 

--- a/src/test/java/com/diamonddagger590/mccore/util/filter/ChainFilterTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/filter/ChainFilterTest.java
@@ -1,0 +1,125 @@
+package com.diamonddagger590.mccore.util.filter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChainFilterTest {
+
+    @Test
+    void singleFilterApplied() {
+        Filter<Integer> evensOnly = collection ->
+                collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
+
+        ChainFilter<Integer> chain = new ChainFilter<>(evensOnly);
+        Collection<Integer> result = chain.filter(new ArrayList<>(List.of(1, 2, 3, 4, 5, 6)));
+
+        assertEquals(List.of(2, 4, 6), new ArrayList<>(result));
+    }
+
+    @Test
+    void multipleFiltersAppliedInOrder() {
+        Filter<Integer> evensOnly = collection ->
+                collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
+
+        Filter<Integer> greaterThanThree = collection ->
+                collection.stream().filter(n -> n > 3).collect(Collectors.toList());
+
+        ChainFilter<Integer> chain = new ChainFilter<>(evensOnly, greaterThanThree);
+        Collection<Integer> result = chain.filter(new ArrayList<>(List.of(1, 2, 3, 4, 5, 6)));
+
+        assertEquals(List.of(4, 6), new ArrayList<>(result));
+    }
+
+    @Test
+    void filterOrderMatters() {
+        Filter<String> takeFirstTwo = collection ->
+                collection.stream().limit(2).collect(Collectors.toList());
+
+        Filter<String> keepLong = collection ->
+                collection.stream().filter(s -> s.length() > 3).collect(Collectors.toList());
+
+        ChainFilter<String> longThenLimit = new ChainFilter<>(keepLong, takeFirstTwo);
+        ChainFilter<String> limitThenLong = new ChainFilter<>(takeFirstTwo, keepLong);
+
+        List<String> input = new ArrayList<>(List.of("ab", "abcde", "cd", "efghi", "fghij"));
+
+        Collection<String> result1 = longThenLimit.filter(new ArrayList<>(input));
+        assertEquals(List.of("abcde", "efghi"), new ArrayList<>(result1));
+
+        Collection<String> result2 = limitThenLong.filter(new ArrayList<>(input));
+        assertEquals(List.of("abcde"), new ArrayList<>(result2));
+    }
+
+    @Test
+    void emptyInputReturnsEmpty() {
+        Filter<Integer> evensOnly = collection ->
+                collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
+
+        ChainFilter<Integer> chain = new ChainFilter<>(evensOnly);
+        Collection<Integer> result = chain.filter(new ArrayList<>());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void filterThatRemovesAllReturnsEmpty() {
+        Filter<Integer> removeAll = collection ->
+                collection.stream().filter(n -> false).collect(Collectors.toList());
+
+        ChainFilter<Integer> chain = new ChainFilter<>(removeAll);
+        Collection<Integer> result = chain.filter(new ArrayList<>(List.of(1, 2, 3)));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void identityFilterReturnsAllElements() {
+        Filter<String> identity = collection -> collection;
+
+        ChainFilter<String> chain = new ChainFilter<>(identity);
+        Collection<String> input = new ArrayList<>(List.of("a", "b", "c"));
+        Collection<String> result = chain.filter(input);
+
+        assertEquals(List.of("a", "b", "c"), new ArrayList<>(result));
+    }
+
+    @Test
+    void threeFiltersChained() {
+        Filter<Integer> removeNegatives = collection ->
+                collection.stream().filter(n -> n >= 0).collect(Collectors.toList());
+
+        Filter<Integer> evensOnly = collection ->
+                collection.stream().filter(n -> n % 2 == 0).collect(Collectors.toList());
+
+        Filter<Integer> lessThanTen = collection ->
+                collection.stream().filter(n -> n < 10).collect(Collectors.toList());
+
+        ChainFilter<Integer> chain = new ChainFilter<>(removeNegatives, evensOnly, lessThanTen);
+        Collection<Integer> result = chain.filter(
+                new ArrayList<>(List.of(-2, -1, 0, 1, 2, 3, 4, 5, 6, 10, 12)));
+
+        assertEquals(List.of(0, 2, 4, 6), new ArrayList<>(result));
+    }
+
+    @Test
+    void stringFilterChain() {
+        Filter<String> nonEmpty = collection ->
+                collection.stream().filter(s -> !s.isEmpty()).collect(Collectors.toList());
+
+        Filter<String> startsWithA = collection ->
+                collection.stream().filter(s -> s.startsWith("a")).collect(Collectors.toList());
+
+        ChainFilter<String> chain = new ChainFilter<>(nonEmpty, startsWithA);
+        Collection<String> result = chain.filter(
+                new ArrayList<>(List.of("apple", "", "banana", "avocado", "cherry", "")));
+
+        assertEquals(List.of("apple", "avocado"), new ArrayList<>(result));
+    }
+}


### PR DESCRIPTION
## Summary

- **ParserTest** (45 tests): Covers arithmetic operators, operator precedence, parentheses, unary negation, exponentiation, decimal/scientific notation, built-in constants (pi, e), built-in functions (sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, abs, sqrt, exp, ln, log, log2), variable substitution/reassignment, implicit multiplication, parsed variables/functions retrieval, parse error cases, and complex expressions.
- **PairTest** (15 tests): Covers ImmutablePair and MutablePair creation via factory methods, MutablePair setLeft/setRight mutation, equals/hashCode contract, cross-type equality (ImmutablePair == MutablePair with same values), toString format, and equality after mutation.
- **LinkedNodeTest** (11 tests): Covers single-node value retrieval, hasNext/getNextNode behavior, two-arg constructor linking, setNext override, chain traversal, different generic types, and NullPointerException message content.
- **ChainComparatorTest** (7 tests): Covers single comparator delegation, first-comparator-wins, second-comparator-on-tie, all-zero fallthrough, list sorting, three-comparator chain, and reverse ordering.
- **ChainFilterTest** (8 tests): Covers single filter, multi-filter chaining, filter order sensitivity, empty input, remove-all filter, identity filter, three-filter chain, and string filter chain.

All tests target pure-Java utility classes with zero Bukkit dependencies — no MockBukkit or server mock required. All tests use Given/When/Then `@DisplayName` annotations.

## Test plan

- [ ] CI passes `./gradlew test` with all 86 new tests green
- [ ] Existing statistic tests remain unaffected
- [ ] No production code changes — test-only PR

https://claude.ai/code/session_01XNieTaSq6eNEztJ9fa8Wkq