### PR TITLE
Extend Javadoc requirement to all methods, public and private

### DIFF
--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -66,7 +66,7 @@ Built-in `CoreManagerKey` constants: `CORE_GUI_MANAGER`, `CORE_PLAYER_MANAGER`, 
 
 - 4-space indentation, K&R brace style (standard Java)
 - Prefer `var` for local variables when the declared type is long/nested; otherwise prefer explicit types
-- Javadoc on all public methods with `@param` and `@return` semantics
+- Javadoc on all methods (public and private) with `@param` and `@return` semantics
 - **Third-party developer mindset:** Public APIs are consumed by downstream plugins. Write and review changes as if you are that downstream developer.
 
 ## Anti-Patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ Register with `ReloadableContentManager` so it refreshes automatically on `/relo
 - Meaningful variable names — avoid single-letter names except loop counters
 - Prefer `var` for local variables when the declared type is long/nested and would be more distracting than helpful; otherwise prefer explicit types
 - Keep methods focused and short — split logic into private helpers rather than long method bodies
-- Javadoc on all public methods with `@param` and `@return` semantics
+- Javadoc on all methods (public and private) with `@param` and `@return` semantics
 
 **Third-party developer mindset:** McCore is extended by downstream plugins. Any change to a public API, interface, or registry must be made as if you were that downstream developer. Prefer additive, non-breaking changes. Document extension points clearly. When removing or changing a public API, consider providing a deprecation path first.
 


### PR DESCRIPTION
## Summary
Updated documentation standards to require Javadoc on all methods (both public and private) with `@param` and `@return` semantics, rather than only public methods.

## Changes
- Updated `.cursor/rules/core.mdc` to reflect the expanded Javadoc requirement
- Updated `CLAUDE.md` to match the same documentation standard

## Rationale
Comprehensive Javadoc coverage on all methods—including private helpers—improves code maintainability and clarity. This is particularly important in McCore given its role as a framework library consumed by downstream plugins. Clear documentation of internal implementation details helps future maintainers and contributors understand the codebase more effectively.

https://claude.ai/code/session_01Ln8kpPanSWnnjZEsfMNKwg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal coding standards to require comprehensive documentation for all methods (both public and private) with full parameter and return value specifications.

---

**Note:** This is an internal standards update with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->