### PR TITLE
[Tests] Add unit tests for BootstrapContext, IllegalSlotAssignmentException, TableVersionHistoryDAO, MutexDAO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testFixturesApi("org.junit.jupiter:junit-jupiter:$junitVersion")
 
+    val mockitoVersion = "5.14.2"
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
+
     val paperVersion = "1.21.11-R0.1-SNAPSHOT"
     compileOnlyApi("io.papermc.paper:paper-api:$paperVersion")
     testImplementation("io.papermc.paper:paper-api:$paperVersion")

--- a/src/test/java/com/diamonddagger590/mccore/bootstrap/BootstrapContextTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/bootstrap/BootstrapContextTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class BootstrapContextTest {
@@ -21,64 +22,64 @@ class BootstrapContextTest {
     private CorePlugin anotherMockPlugin;
 
     @Test
-    @DisplayName("Given a plugin and PROD profile, When constructing BootstrapContext, Then plugin() returns the plugin")
-    void pluginAccessor() {
+    @DisplayName("Given a plugin and PROD profile, when constructing BootstrapContext, then plugin() returns the plugin")
+    void plugin_returnsPlugin_whenConstructedWithProdProfile() {
         var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         assertEquals(mockPlugin, context.plugin());
     }
 
     @Test
-    @DisplayName("Given a plugin and TEST profile, When constructing BootstrapContext, Then startupProfile() returns TEST")
-    void startupProfileAccessor() {
+    @DisplayName("Given a plugin and TEST profile, when constructing BootstrapContext, then startupProfile() returns TEST")
+    void startupProfile_returnsTest_whenConstructedWithTestProfile() {
         var context = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
         assertEquals(StartupProfile.TEST, context.startupProfile());
     }
 
     @Test
-    @DisplayName("Given a plugin and PROD profile, When constructing BootstrapContext, Then startupProfile() returns PROD")
-    void prodProfileAccessor() {
+    @DisplayName("Given a plugin and PROD profile, when constructing BootstrapContext, then startupProfile() returns PROD")
+    void startupProfile_returnsProd_whenConstructedWithProdProfile() {
         var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         assertEquals(StartupProfile.PROD, context.startupProfile());
     }
 
     @Test
-    @DisplayName("Given two BootstrapContexts with same plugin and profile, When comparing, Then they are equal")
-    void equalContexts() {
+    @DisplayName("Given two BootstrapContexts with same plugin and profile, when comparing, then they are equal")
+    void equals_returnsTrue_whenSamePluginAndProfile() {
         var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         assertEquals(context1, context2);
     }
 
     @Test
-    @DisplayName("Given two BootstrapContexts with different profiles, When comparing, Then they are not equal")
-    void differentProfiles() {
+    @DisplayName("Given two BootstrapContexts with different profiles, when comparing, then they are not equal")
+    void equals_returnsFalse_whenDifferentProfiles() {
         var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
         assertNotEquals(context1, context2);
     }
 
     @Test
-    @DisplayName("Given two BootstrapContexts with different plugins, When comparing, Then they are not equal")
-    void differentPlugins() {
+    @DisplayName("Given two BootstrapContexts with different plugins, when comparing, then they are not equal")
+    void equals_returnsFalse_whenDifferentPlugins() {
         var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         var context2 = new BootstrapContext<>(anotherMockPlugin, StartupProfile.PROD);
         assertNotEquals(context1, context2);
     }
 
     @Test
-    @DisplayName("Given two equal BootstrapContexts, When computing hashCode, Then they match")
-    void hashCodeConsistency() {
+    @DisplayName("Given two equal BootstrapContexts, when computing hashCode, then they match")
+    void hashCode_matches_whenContextsAreEqual() {
         var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
         var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
         assertEquals(context1.hashCode(), context2.hashCode());
     }
 
     @Test
-    @DisplayName("Given a BootstrapContext, When calling toString, Then it contains the class name")
-    void toStringContainsClassName() {
+    @DisplayName("Given a BootstrapContext, when calling toString, then it contains the class name")
+    void toString_containsClassName_whenCalled() {
         var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
         String str = context.toString();
         assertNotNull(str);
-        assertEquals(true, str.contains("BootstrapContext"));
+        assertTrue(str.contains("BootstrapContext"));
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/bootstrap/BootstrapContextTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/bootstrap/BootstrapContextTest.java
@@ -1,0 +1,84 @@
+package com.diamonddagger590.mccore.bootstrap;
+
+import com.diamonddagger590.mccore.CorePlugin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class BootstrapContextTest {
+
+    @Mock
+    private CorePlugin mockPlugin;
+
+    @Mock
+    private CorePlugin anotherMockPlugin;
+
+    @Test
+    @DisplayName("Given a plugin and PROD profile, When constructing BootstrapContext, Then plugin() returns the plugin")
+    void pluginAccessor() {
+        var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        assertEquals(mockPlugin, context.plugin());
+    }
+
+    @Test
+    @DisplayName("Given a plugin and TEST profile, When constructing BootstrapContext, Then startupProfile() returns TEST")
+    void startupProfileAccessor() {
+        var context = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
+        assertEquals(StartupProfile.TEST, context.startupProfile());
+    }
+
+    @Test
+    @DisplayName("Given a plugin and PROD profile, When constructing BootstrapContext, Then startupProfile() returns PROD")
+    void prodProfileAccessor() {
+        var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        assertEquals(StartupProfile.PROD, context.startupProfile());
+    }
+
+    @Test
+    @DisplayName("Given two BootstrapContexts with same plugin and profile, When comparing, Then they are equal")
+    void equalContexts() {
+        var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        assertEquals(context1, context2);
+    }
+
+    @Test
+    @DisplayName("Given two BootstrapContexts with different profiles, When comparing, Then they are not equal")
+    void differentProfiles() {
+        var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
+        assertNotEquals(context1, context2);
+    }
+
+    @Test
+    @DisplayName("Given two BootstrapContexts with different plugins, When comparing, Then they are not equal")
+    void differentPlugins() {
+        var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        var context2 = new BootstrapContext<>(anotherMockPlugin, StartupProfile.PROD);
+        assertNotEquals(context1, context2);
+    }
+
+    @Test
+    @DisplayName("Given two equal BootstrapContexts, When computing hashCode, Then they match")
+    void hashCodeConsistency() {
+        var context1 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
+        var context2 = new BootstrapContext<>(mockPlugin, StartupProfile.TEST);
+        assertEquals(context1.hashCode(), context2.hashCode());
+    }
+
+    @Test
+    @DisplayName("Given a BootstrapContext, When calling toString, Then it contains the class name")
+    void toStringContainsClassName() {
+        var context = new BootstrapContext<>(mockPlugin, StartupProfile.PROD);
+        String str = context.toString();
+        assertNotNull(str);
+        assertEquals(true, str.contains("BootstrapContext"));
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/MutexDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/MutexDAOTest.java
@@ -1,0 +1,260 @@
+package com.diamonddagger590.mccore.database.table.impl;
+
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.player.CorePlayer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MutexDAOTest {
+
+    @Mock
+    private Connection mockConnection;
+
+    @Mock
+    private PreparedStatement mockStatement;
+
+    @Mock
+    private ResultSet mockResultSet;
+
+    @Mock
+    private Database mockDatabase;
+
+    @Mock
+    private CorePlayer mockCorePlayer;
+
+    private static final UUID TEST_UUID = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @Test
+        @DisplayName("Given the table already exists, When attemptCreateTable is called, Then it returns false")
+        void returnsFalseWhenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(true);
+
+            boolean result = MutexDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given the table doesn't exist, When attemptCreateTable is called, Then it creates the table and returns true")
+        void returnsTrueWhenTableCreated() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = MutexDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception during creation, When attemptCreateTable is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Create failed"));
+
+            boolean result = MutexDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @Test
+        @DisplayName("Given the table is at current version, When updateTable is called, Then no updates are performed")
+        void noUpdateWhenCurrent() throws SQLException {
+            // getLatestVersion for "player_mutex" returns 1 (current version)
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(1);
+
+            MutexDAO.updateTable(mockConnection);
+
+            verify(mockStatement).setString(1, "player_mutex");
+        }
+
+        @Test
+        @DisplayName("Given the table is at version 0, When updateTable is called, Then it updates to version 1")
+        void updatesFromVersion0To1() throws SQLException {
+            // First call: getLatestVersion returns 0 (no version)
+            PreparedStatement selectStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+            ResultSet selectResultSet = org.mockito.Mockito.mock(ResultSet.class);
+            when(selectStatement.executeQuery()).thenReturn(selectResultSet);
+            when(selectResultSet.next()).thenReturn(false);
+
+            // Second call: setTableVersion
+            PreparedStatement updateStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+
+            when(mockConnection.prepareStatement(anyString()))
+                    .thenReturn(selectStatement)
+                    .thenReturn(updateStatement);
+
+            MutexDAO.updateTable(mockConnection);
+
+            verify(updateStatement).setString(1, "player_mutex");
+            verify(updateStatement).setInt(3, 1);
+            verify(updateStatement).executeUpdate();
+        }
+    }
+
+    @Nested
+    @DisplayName("isUserMutexLocked")
+    class IsUserMutexLocked {
+
+        @Test
+        @DisplayName("Given a locked user exists, When isUserMutexLocked is called, Then it returns true")
+        void returnsTrueWhenLocked() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getBoolean("mutex")).thenReturn(true);
+
+            boolean result = MutexDAO.isUserMutexLocked(mockConnection, TEST_UUID);
+
+            assertTrue(result);
+            verify(mockStatement).setString(1, TEST_UUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given an unlocked user exists, When isUserMutexLocked is called, Then it returns false")
+        void returnsFalseWhenUnlocked() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getBoolean("mutex")).thenReturn(false);
+
+            boolean result = MutexDAO.isUserMutexLocked(mockConnection, TEST_UUID);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given no user record exists, When isUserMutexLocked is called, Then it returns false")
+        void returnsFalseWhenNoRecord() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            boolean result = MutexDAO.isUserMutexLocked(mockConnection, TEST_UUID);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, When isUserMutexLocked is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Query failed"));
+
+            boolean result = MutexDAO.isUserMutexLocked(mockConnection, TEST_UUID);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserMutex with CorePlayer")
+    class UpdateUserMutexWithCorePlayer {
+
+        @Test
+        @DisplayName("Given a locked CorePlayer, When updateUserMutex is called, Then it returns true")
+        void returnsTrueWhenLocked() throws SQLException {
+            when(mockCorePlayer.getUUID()).thenReturn(TEST_UUID);
+            when(mockCorePlayer.isLocked()).thenReturn(true);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, mockCorePlayer);
+
+            assertTrue(result);
+            verify(mockStatement).setString(1, TEST_UUID.toString());
+            verify(mockStatement).setBoolean(2, true);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given an unlocked CorePlayer, When updateUserMutex is called, Then it returns false")
+        void returnsFalseWhenUnlocked() throws SQLException {
+            when(mockCorePlayer.getUUID()).thenReturn(TEST_UUID);
+            when(mockCorePlayer.isLocked()).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, mockCorePlayer);
+
+            assertFalse(result);
+            verify(mockStatement).setBoolean(2, false);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, When updateUserMutex with CorePlayer is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Update failed"));
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, mockCorePlayer);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserMutex with UUID and boolean")
+    class UpdateUserMutexWithUUID {
+
+        @Test
+        @DisplayName("Given a UUID and locked=true, When updateUserMutex is called, Then it returns true")
+        void returnsTrueWhenLocking() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, true);
+
+            assertTrue(result);
+            verify(mockStatement).setString(1, TEST_UUID.toString());
+            verify(mockStatement).setBoolean(2, true);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given a UUID and locked=false, When updateUserMutex is called, Then it returns false")
+        void returnsFalseWhenUnlocking() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, false);
+
+            assertFalse(result);
+            verify(mockStatement).setBoolean(2, false);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, When updateUserMutex with UUID is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Update failed"));
+
+            boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, true);
+
+            assertFalse(result);
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/MutexDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/MutexDAOTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,8 +48,8 @@ class MutexDAOTest {
     class AttemptCreateTable {
 
         @Test
-        @DisplayName("Given the table already exists, When attemptCreateTable is called, Then it returns false")
-        void returnsFalseWhenTableExists() {
+        @DisplayName("Given the table already exists, when attemptCreateTable is called, then it returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
             when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(true);
 
             boolean result = MutexDAO.attemptCreateTable(mockConnection, mockDatabase);
@@ -57,8 +58,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given the table doesn't exist, When attemptCreateTable is called, Then it creates the table and returns true")
-        void returnsTrueWhenTableCreated() throws SQLException {
+        @DisplayName("Given the table doesn't exist, when attemptCreateTable is called, then it creates the table and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreatedSuccessfully() throws SQLException {
             when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(false);
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
@@ -69,8 +70,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception during creation, When attemptCreateTable is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception during creation, when attemptCreateTable is called, then it returns false")
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
             when(mockDatabase.tableExists(mockConnection, "player_mutex")).thenReturn(false);
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Create failed"));
 
@@ -85,9 +86,8 @@ class MutexDAOTest {
     class UpdateTable {
 
         @Test
-        @DisplayName("Given the table is at current version, When updateTable is called, Then no updates are performed")
-        void noUpdateWhenCurrent() throws SQLException {
-            // getLatestVersion for "player_mutex" returns 1 (current version)
+        @DisplayName("Given the table is at current version, when updateTable is called, then no updates are performed")
+        void updateTable_performsNoUpdate_whenVersionIsCurrent() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -96,18 +96,17 @@ class MutexDAOTest {
             MutexDAO.updateTable(mockConnection);
 
             verify(mockStatement).setString(1, "player_mutex");
+            verify(mockStatement, never()).executeUpdate();
         }
 
         @Test
-        @DisplayName("Given the table is at version 0, When updateTable is called, Then it updates to version 1")
-        void updatesFromVersion0To1() throws SQLException {
-            // First call: getLatestVersion returns 0 (no version)
+        @DisplayName("Given the table is at version 0, when updateTable is called, then it updates to version 1")
+        void updateTable_updatesToVersion1_whenVersionIsZero() throws SQLException {
             PreparedStatement selectStatement = org.mockito.Mockito.mock(PreparedStatement.class);
             ResultSet selectResultSet = org.mockito.Mockito.mock(ResultSet.class);
             when(selectStatement.executeQuery()).thenReturn(selectResultSet);
             when(selectResultSet.next()).thenReturn(false);
 
-            // Second call: setTableVersion
             PreparedStatement updateStatement = org.mockito.Mockito.mock(PreparedStatement.class);
 
             when(mockConnection.prepareStatement(anyString()))
@@ -127,8 +126,8 @@ class MutexDAOTest {
     class IsUserMutexLocked {
 
         @Test
-        @DisplayName("Given a locked user exists, When isUserMutexLocked is called, Then it returns true")
-        void returnsTrueWhenLocked() throws SQLException {
+        @DisplayName("Given a locked user exists, when isUserMutexLocked is called, then it returns true")
+        void isUserMutexLocked_returnsTrue_whenUserIsLocked() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -141,8 +140,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given an unlocked user exists, When isUserMutexLocked is called, Then it returns false")
-        void returnsFalseWhenUnlocked() throws SQLException {
+        @DisplayName("Given an unlocked user exists, when isUserMutexLocked is called, then it returns false")
+        void isUserMutexLocked_returnsFalse_whenUserIsUnlocked() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -154,8 +153,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given no user record exists, When isUserMutexLocked is called, Then it returns false")
-        void returnsFalseWhenNoRecord() throws SQLException {
+        @DisplayName("Given no user record exists, when isUserMutexLocked is called, then it returns false")
+        void isUserMutexLocked_returnsFalse_whenNoRecordExists() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(false);
@@ -166,8 +165,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception occurs, When isUserMutexLocked is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception occurs, when isUserMutexLocked is called, then it returns false")
+        void isUserMutexLocked_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Query failed"));
 
             boolean result = MutexDAO.isUserMutexLocked(mockConnection, TEST_UUID);
@@ -181,8 +180,8 @@ class MutexDAOTest {
     class UpdateUserMutexWithCorePlayer {
 
         @Test
-        @DisplayName("Given a locked CorePlayer, When updateUserMutex is called, Then it returns true")
-        void returnsTrueWhenLocked() throws SQLException {
+        @DisplayName("Given a locked CorePlayer, when updateUserMutex is called, then it returns true")
+        void updateUserMutex_returnsTrue_whenCorePlayerIsLocked() throws SQLException {
             when(mockCorePlayer.getUUID()).thenReturn(TEST_UUID);
             when(mockCorePlayer.isLocked()).thenReturn(true);
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
@@ -196,8 +195,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given an unlocked CorePlayer, When updateUserMutex is called, Then it returns false")
-        void returnsFalseWhenUnlocked() throws SQLException {
+        @DisplayName("Given an unlocked CorePlayer, when updateUserMutex is called, then it returns false")
+        void updateUserMutex_returnsFalse_whenCorePlayerIsUnlocked() throws SQLException {
             when(mockCorePlayer.getUUID()).thenReturn(TEST_UUID);
             when(mockCorePlayer.isLocked()).thenReturn(false);
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
@@ -209,8 +208,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception occurs, When updateUserMutex with CorePlayer is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception occurs, when updateUserMutex with CorePlayer is called, then it returns false")
+        void updateUserMutex_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Update failed"));
 
             boolean result = MutexDAO.updateUserMutex(mockConnection, mockCorePlayer);
@@ -224,8 +223,8 @@ class MutexDAOTest {
     class UpdateUserMutexWithUUID {
 
         @Test
-        @DisplayName("Given a UUID and locked=true, When updateUserMutex is called, Then it returns true")
-        void returnsTrueWhenLocking() throws SQLException {
+        @DisplayName("Given a UUID and locked=true, when updateUserMutex is called, then it returns true")
+        void updateUserMutex_returnsTrue_whenLockingWithUuid() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
             boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, true);
@@ -237,8 +236,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given a UUID and locked=false, When updateUserMutex is called, Then it returns false")
-        void returnsFalseWhenUnlocking() throws SQLException {
+        @DisplayName("Given a UUID and locked=false, when updateUserMutex is called, then it returns false")
+        void updateUserMutex_returnsFalse_whenUnlockingWithUuid() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
             boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, false);
@@ -248,8 +247,8 @@ class MutexDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception occurs, When updateUserMutex with UUID is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception occurs, when updateUserMutex with UUID is called, then it returns false")
+        void updateUserMutex_returnsFalse_whenSqlExceptionOccursWithUuid() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Update failed"));
 
             boolean result = MutexDAO.updateUserMutex(mockConnection, TEST_UUID, true);

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/TableVersionHistoryDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/TableVersionHistoryDAOTest.java
@@ -1,0 +1,223 @@
+package com.diamonddagger590.mccore.database.table.impl;
+
+import com.diamonddagger590.mccore.database.Database;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TableVersionHistoryDAOTest {
+
+    @Mock
+    private Connection mockConnection;
+
+    @Mock
+    private PreparedStatement mockStatement;
+
+    @Mock
+    private ResultSet mockResultSet;
+
+    @Mock
+    private Database mockDatabase;
+
+    @Nested
+    @DisplayName("getLatestVersion")
+    class GetLatestVersion {
+
+        @Test
+        @DisplayName("Given a table with version 3 stored, When getLatestVersion is called, Then it returns 3")
+        void returnsStoredVersion() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(3);
+
+            int version = TableVersionHistoryDAO.getLatestVersion(mockConnection, "test_table");
+
+            assertEquals(3, version);
+            verify(mockStatement).setString(1, "test_table");
+        }
+
+        @Test
+        @DisplayName("Given a table with no version stored, When getLatestVersion is called, Then it returns 0")
+        void returnsZeroForMissingTable() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            int version = TableVersionHistoryDAO.getLatestVersion(mockConnection, "nonexistent_table");
+
+            assertEquals(0, version);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, When getLatestVersion is called, Then it returns 0")
+        void returnsZeroOnSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Connection failed"));
+
+            int version = TableVersionHistoryDAO.getLatestVersion(mockConnection, "test_table");
+
+            assertEquals(0, version);
+        }
+
+        @Test
+        @DisplayName("Given multiple rows returned, When getLatestVersion is called, Then it returns the last row's version")
+        void returnsLastRowVersion() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(1, 5);
+
+            int version = TableVersionHistoryDAO.getLatestVersion(mockConnection, "test_table");
+
+            assertEquals(5, version);
+        }
+    }
+
+    @Nested
+    @DisplayName("setTableVersion")
+    class SetTableVersion {
+
+        @Test
+        @DisplayName("Given a valid connection, When setTableVersion is called, Then it returns true")
+        void returnsTrueOnSuccess() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = TableVersionHistoryDAO.setTableVersion(mockConnection, "test_table", 2);
+
+            assertTrue(result);
+            verify(mockStatement).setString(1, "test_table");
+            verify(mockStatement).setInt(3, 2);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, When setTableVersion is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Write failed"));
+
+            boolean result = TableVersionHistoryDAO.setTableVersion(mockConnection, "test_table", 1);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given a statement execution failure, When setTableVersion is called, Then it returns false")
+        void returnsFalseOnExecuteFailure() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenThrow(new SQLException("Execute failed"));
+
+            boolean result = TableVersionHistoryDAO.setTableVersion(mockConnection, "test_table", 1);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @Test
+        @DisplayName("Given the table already exists, When attemptCreateTable is called, Then it returns false")
+        void returnsFalseWhenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(true);
+
+            boolean result = TableVersionHistoryDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given the table doesn't exist, When attemptCreateTable is called, Then it creates the table and returns true")
+        void returnsTrueWhenTableCreated() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = TableVersionHistoryDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception during creation, When attemptCreateTable is called, Then it returns false")
+        void returnsFalseOnSqlException() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Create failed"));
+
+            boolean result = TableVersionHistoryDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @Test
+        @DisplayName("Given the table is at current version, When updateTable is called, Then no updates are performed")
+        void noUpdateWhenCurrent() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(1);
+
+            TableVersionHistoryDAO.updateTable(mockConnection);
+
+            // getLatestVersion is called but no setTableVersion since version is already current
+            verify(mockStatement).setString(1, "table_history");
+        }
+
+        @Test
+        @DisplayName("Given the table is at version 0, When updateTable is called, Then it updates to version 1")
+        void updatesFromVersion0To1() throws SQLException {
+            // First call: getLatestVersion returns 0
+            PreparedStatement selectStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+            ResultSet selectResultSet = org.mockito.Mockito.mock(ResultSet.class);
+            when(selectStatement.executeQuery()).thenReturn(selectResultSet);
+            when(selectResultSet.next()).thenReturn(false);
+
+            // Second call: setTableVersion
+            PreparedStatement updateStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+
+            when(mockConnection.prepareStatement(anyString()))
+                    .thenReturn(selectStatement)
+                    .thenReturn(updateStatement);
+
+            TableVersionHistoryDAO.updateTable(mockConnection);
+
+            verify(updateStatement).setString(1, "table_history");
+            verify(updateStatement).setInt(3, 1);
+            verify(updateStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given the table is above current version, When updateTable is called, Then no updates are performed")
+        void noUpdateWhenAboveCurrent() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(5);
+
+            TableVersionHistoryDAO.updateTable(mockConnection);
+
+            verify(mockStatement).setString(1, "table_history");
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/TableVersionHistoryDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/TableVersionHistoryDAOTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,8 +41,8 @@ class TableVersionHistoryDAOTest {
     class GetLatestVersion {
 
         @Test
-        @DisplayName("Given a table with version 3 stored, When getLatestVersion is called, Then it returns 3")
-        void returnsStoredVersion() throws SQLException {
+        @DisplayName("Given a table with version 3 stored, when getLatestVersion is called, then it returns 3")
+        void getLatestVersion_returnsStoredVersion_whenTableHasVersion() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -54,8 +55,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given a table with no version stored, When getLatestVersion is called, Then it returns 0")
-        void returnsZeroForMissingTable() throws SQLException {
+        @DisplayName("Given a table with no version stored, when getLatestVersion is called, then it returns 0")
+        void getLatestVersion_returnsZero_whenTableHasNoVersion() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(false);
@@ -66,8 +67,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception occurs, When getLatestVersion is called, Then it returns 0")
-        void returnsZeroOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception occurs, when getLatestVersion is called, then it returns 0")
+        void getLatestVersion_returnsZero_whenSqlExceptionOccurs() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Connection failed"));
 
             int version = TableVersionHistoryDAO.getLatestVersion(mockConnection, "test_table");
@@ -76,8 +77,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given multiple rows returned, When getLatestVersion is called, Then it returns the last row's version")
-        void returnsLastRowVersion() throws SQLException {
+        @DisplayName("Given multiple rows returned, when getLatestVersion is called, then it returns the last row's version")
+        void getLatestVersion_returnsLastRowVersion_whenMultipleRowsExist() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, true, false);
@@ -94,8 +95,8 @@ class TableVersionHistoryDAOTest {
     class SetTableVersion {
 
         @Test
-        @DisplayName("Given a valid connection, When setTableVersion is called, Then it returns true")
-        void returnsTrueOnSuccess() throws SQLException {
+        @DisplayName("Given a valid connection, when setTableVersion is called, then it returns true")
+        void setTableVersion_returnsTrue_whenUpdateSucceeds() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
             boolean result = TableVersionHistoryDAO.setTableVersion(mockConnection, "test_table", 2);
@@ -107,8 +108,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception occurs, When setTableVersion is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception occurs, when setTableVersion is called, then it returns false")
+        void setTableVersion_returnsFalse_whenPrepareStatementFails() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Write failed"));
 
             boolean result = TableVersionHistoryDAO.setTableVersion(mockConnection, "test_table", 1);
@@ -117,8 +118,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given a statement execution failure, When setTableVersion is called, Then it returns false")
-        void returnsFalseOnExecuteFailure() throws SQLException {
+        @DisplayName("Given a statement execution failure, when setTableVersion is called, then it returns false")
+        void setTableVersion_returnsFalse_whenExecuteUpdateFails() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeUpdate()).thenThrow(new SQLException("Execute failed"));
 
@@ -133,8 +134,8 @@ class TableVersionHistoryDAOTest {
     class AttemptCreateTable {
 
         @Test
-        @DisplayName("Given the table already exists, When attemptCreateTable is called, Then it returns false")
-        void returnsFalseWhenTableExists() {
+        @DisplayName("Given the table already exists, when attemptCreateTable is called, then it returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
             when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(true);
 
             boolean result = TableVersionHistoryDAO.attemptCreateTable(mockConnection, mockDatabase);
@@ -143,8 +144,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given the table doesn't exist, When attemptCreateTable is called, Then it creates the table and returns true")
-        void returnsTrueWhenTableCreated() throws SQLException {
+        @DisplayName("Given the table doesn't exist, when attemptCreateTable is called, then it creates the table and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreatedSuccessfully() throws SQLException {
             when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(false);
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
@@ -155,8 +156,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given a SQL exception during creation, When attemptCreateTable is called, Then it returns false")
-        void returnsFalseOnSqlException() throws SQLException {
+        @DisplayName("Given a SQL exception during creation, when attemptCreateTable is called, then it returns false")
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
             when(mockDatabase.tableExists(mockConnection, "table_history")).thenReturn(false);
             when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Create failed"));
 
@@ -171,8 +172,8 @@ class TableVersionHistoryDAOTest {
     class UpdateTable {
 
         @Test
-        @DisplayName("Given the table is at current version, When updateTable is called, Then no updates are performed")
-        void noUpdateWhenCurrent() throws SQLException {
+        @DisplayName("Given the table is at current version, when updateTable is called, then no updates are performed")
+        void updateTable_performsNoUpdate_whenVersionIsCurrent() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -180,20 +181,18 @@ class TableVersionHistoryDAOTest {
 
             TableVersionHistoryDAO.updateTable(mockConnection);
 
-            // getLatestVersion is called but no setTableVersion since version is already current
             verify(mockStatement).setString(1, "table_history");
+            verify(mockStatement, never()).executeUpdate();
         }
 
         @Test
-        @DisplayName("Given the table is at version 0, When updateTable is called, Then it updates to version 1")
-        void updatesFromVersion0To1() throws SQLException {
-            // First call: getLatestVersion returns 0
+        @DisplayName("Given the table is at version 0, when updateTable is called, then it updates to version 1")
+        void updateTable_updatesToVersion1_whenVersionIsZero() throws SQLException {
             PreparedStatement selectStatement = org.mockito.Mockito.mock(PreparedStatement.class);
             ResultSet selectResultSet = org.mockito.Mockito.mock(ResultSet.class);
             when(selectStatement.executeQuery()).thenReturn(selectResultSet);
             when(selectResultSet.next()).thenReturn(false);
 
-            // Second call: setTableVersion
             PreparedStatement updateStatement = org.mockito.Mockito.mock(PreparedStatement.class);
 
             when(mockConnection.prepareStatement(anyString()))
@@ -208,8 +207,8 @@ class TableVersionHistoryDAOTest {
         }
 
         @Test
-        @DisplayName("Given the table is above current version, When updateTable is called, Then no updates are performed")
-        void noUpdateWhenAboveCurrent() throws SQLException {
+        @DisplayName("Given the table is above current version, when updateTable is called, then no updates are performed")
+        void updateTable_performsNoUpdate_whenVersionIsAboveCurrent() throws SQLException {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(true, false);
@@ -218,6 +217,7 @@ class TableVersionHistoryDAOTest {
             TableVersionHistoryDAO.updateTable(mockConnection);
 
             verify(mockStatement).setString(1, "table_history");
+            verify(mockStatement, never()).executeUpdate();
         }
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/exception/gui/IllegalSlotAssignmentExceptionTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/exception/gui/IllegalSlotAssignmentExceptionTest.java
@@ -24,22 +24,22 @@ class IllegalSlotAssignmentExceptionTest {
     private Slot<?> mockSlot;
 
     @Test
-    @DisplayName("Given a gui and slot, When constructing IllegalSlotAssignmentException, Then getGui() returns the gui")
-    void getGuiReturnsGui() {
+    @DisplayName("Given a gui and slot, when constructing IllegalSlotAssignmentException, then getGui() returns the gui")
+    void getGui_returnsGui_whenConstructed() {
         var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
         assertEquals(mockGui, exception.getGui());
     }
 
     @Test
-    @DisplayName("Given a gui and slot, When constructing IllegalSlotAssignmentException, Then getSlot() returns the slot")
-    void getSlotReturnsSlot() {
+    @DisplayName("Given a gui and slot, when constructing IllegalSlotAssignmentException, then getSlot() returns the slot")
+    void getSlot_returnsSlot_whenConstructed() {
         var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
         assertEquals(mockSlot, exception.getSlot());
     }
 
     @Test
-    @DisplayName("Given an IllegalSlotAssignmentException, When calling getMessage(), Then it contains GUI and slot details")
-    void getMessageContainsDetails() {
+    @DisplayName("Given an IllegalSlotAssignmentException, when calling getMessage(), then it contains GUI and slot details")
+    void getMessage_containsGuiAndSlotDetails_whenCalled() {
         when(mockGui.toString()).thenReturn("TestGui");
         when(mockSlot.toString()).thenReturn("TestSlot");
 
@@ -53,22 +53,22 @@ class IllegalSlotAssignmentExceptionTest {
     }
 
     @Test
-    @DisplayName("Given an IllegalSlotAssignmentException, When checking inheritance, Then it extends RuntimeException")
-    void extendsRuntimeException() {
+    @DisplayName("Given an IllegalSlotAssignmentException, when checking inheritance, then it extends RuntimeException")
+    void constructor_createsRuntimeException_whenInstantiated() {
         var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
         assertTrue(exception instanceof RuntimeException);
     }
 
     @Test
-    @DisplayName("Given an IllegalSlotAssignmentException, When calling getCause(), Then it returns null (no cause set)")
-    void noCauseSet() {
+    @DisplayName("Given an IllegalSlotAssignmentException, when calling getCause(), then it returns null (no cause set)")
+    void getCause_returnsNull_whenNoCauseProvided() {
         var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
         assertNull(exception.getCause());
     }
 
     @Test
-    @DisplayName("Given an IllegalSlotAssignmentException, When getMessage() is called, Then it has the expected format")
-    void messageFormat() {
+    @DisplayName("Given an IllegalSlotAssignmentException, when getMessage() is called, then it has the expected format")
+    void getMessage_matchesExpectedFormat_whenGuiAndSlotHaveToStrings() {
         when(mockGui.toString()).thenReturn("MyGui@abc");
         when(mockSlot.toString()).thenReturn("MySlot@def");
 

--- a/src/test/java/com/diamonddagger590/mccore/exception/gui/IllegalSlotAssignmentExceptionTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/exception/gui/IllegalSlotAssignmentExceptionTest.java
@@ -1,0 +1,81 @@
+package com.diamonddagger590.mccore.exception.gui;
+
+import com.diamonddagger590.mccore.gui.BaseGui;
+import com.diamonddagger590.mccore.gui.slot.Slot;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IllegalSlotAssignmentExceptionTest {
+
+    @Mock
+    private BaseGui<?> mockGui;
+
+    @Mock
+    private Slot<?> mockSlot;
+
+    @Test
+    @DisplayName("Given a gui and slot, When constructing IllegalSlotAssignmentException, Then getGui() returns the gui")
+    void getGuiReturnsGui() {
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        assertEquals(mockGui, exception.getGui());
+    }
+
+    @Test
+    @DisplayName("Given a gui and slot, When constructing IllegalSlotAssignmentException, Then getSlot() returns the slot")
+    void getSlotReturnsSlot() {
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        assertEquals(mockSlot, exception.getSlot());
+    }
+
+    @Test
+    @DisplayName("Given an IllegalSlotAssignmentException, When calling getMessage(), Then it contains GUI and slot details")
+    void getMessageContainsDetails() {
+        when(mockGui.toString()).thenReturn("TestGui");
+        when(mockSlot.toString()).thenReturn("TestSlot");
+
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        String message = exception.getMessage();
+
+        assertNotNull(message);
+        assertTrue(message.contains("TestGui"));
+        assertTrue(message.contains("TestSlot"));
+        assertTrue(message.contains("not allowed"));
+    }
+
+    @Test
+    @DisplayName("Given an IllegalSlotAssignmentException, When checking inheritance, Then it extends RuntimeException")
+    void extendsRuntimeException() {
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        assertTrue(exception instanceof RuntimeException);
+    }
+
+    @Test
+    @DisplayName("Given an IllegalSlotAssignmentException, When calling getCause(), Then it returns null (no cause set)")
+    void noCauseSet() {
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    @DisplayName("Given an IllegalSlotAssignmentException, When getMessage() is called, Then it has the expected format")
+    void messageFormat() {
+        when(mockGui.toString()).thenReturn("MyGui@abc");
+        when(mockSlot.toString()).thenReturn("MySlot@def");
+
+        var exception = new IllegalSlotAssignmentException(mockGui, mockSlot);
+        assertEquals(
+                "GUI MyGui@abc had slot MySlot@def requested to be added. The GUI is not allowed for that slot type.",
+                exception.getMessage()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **BootstrapContextTest**: Tests record accessors (plugin(), startupProfile()), record equality with same/different plugins/profiles, hashCode consistency, and toString representation (0% → 100% line coverage, 1/1 line)
- **IllegalSlotAssignmentExceptionTest**: Tests constructor field storage, getGui()/getSlot() accessors, getMessage() format containing GUI and slot details, RuntimeException inheritance, and null cause verification (0% → 100% line coverage, 7/7 lines)
- **TableVersionHistoryDAOTest**: Tests getLatestVersion() for stored version, missing table (returns 0), SQL exception handling, and multi-row iteration; setTableVersion() success/failure paths; attemptCreateTable() when table exists vs doesn't exist vs SQL exception; updateTable() from version 0→1 and no-op when current/above current (0% → 97.4% line coverage, 37/38 lines; remaining 1 line is the class declaration)
- **MutexDAOTest**: Tests attemptCreateTable() when table exists vs creation vs SQL exception; updateTable() from version 0→1 and no-op when current; isUserMutexLocked() for locked/unlocked/missing/exception cases; updateUserMutex(CorePlayer) for locked/unlocked/exception paths; updateUserMutex(UUID, boolean) for lock/unlock/exception paths (0% → 97.7% line coverage, 42/43 lines; remaining 1 line is the class declaration)

### Infrastructure change
Added Mockito 5.14.2 as a `testImplementation` dependency to enable mocking JDBC components (Connection, PreparedStatement, ResultSet), Database, CorePlugin, BaseGui, Slot, and CorePlayer for testing classes that depend on framework types.

### Classes covered (avoiding PR #27, PR #30, PR #31, PR #32, PR #33, and PR #34 overlap)
PR #27 covers GetItemRequest, StatisticEntry, ReloadableContent, ReloadableContentManager, StartupProfile. PR #30 covers RegistryAccess, StatisticModifyEvent, PostStatisticModifyEvent, Transaction. PR #31 covers database events, GUI events, SQLiteDatabaseDriver, DatabaseDriver, ManagerKey/PluginHookKey constants. PR #32 covers player events, CorePlayer, Credentials, ConnectionDetails, CorePlayerOfflineException. PR #33 covers PlayerStatisticData, ReloadableParser, ItemPluginType, ChainPlayerContextFilter. PR #34 covers BatchTransaction, FailSafeTransaction, ItemBuilderConfigurationKeys, RegistryKeyImpl. This PR targets entirely different classes with no overlap.

### Coverage impact
4 classes improved: 2 brought from 0% to 100%, 2 brought from 0% to ~97.7%. Overall project coverage: 31.9% → 34.2% (+2.3pp, 94 new lines covered).

## Test plan

- [x] All 664 tests pass via `./gradlew test`
- [x] JaCoCo coverage report confirms expected coverage on all 4 targeted classes
- [x] No existing tests broken by these additions
- [x] No production code changes — test-only PR (plus Mockito dependency addition)

https://claude.ai/code/session_0183JW46S7Paz6fmccowQB3S

---
_Generated by [Claude Code](https://claude.ai/code/session_0183JW46S7Paz6fmccowQB3S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for `BootstrapContext`, `MutexDAO`, `TableVersionHistoryDAO`, and `IllegalSlotAssignmentException` classes with Mockito-based unit tests.
  * Integrated Mockito test framework dependencies to support mock-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->