### PR TITLE
[Tests] Add unit tests for CustomItemWrapper, CustomEntityWrapper, CustomBlockWrapper

### DIFF
--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomBlockWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomBlockWrapperTest.java
@@ -1,7 +1,18 @@
 package com.diamonddagger590.mccore.util.item;
 
+import com.diamonddagger590.mccore.CorePlugin;
+import com.diamonddagger590.mccore.external.common.CustomBlockHook;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.registry.plugin.PluginHook;
 import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +20,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,51 +56,97 @@ class CustomBlockWrapperTest {
         return wrapper;
     }
 
-    // ── Material constructor ────────────────────────────────────────────────
+    static class TestCustomBlockPluginHook extends PluginHook<CorePlugin> implements CustomBlockHook {
+
+        TestCustomBlockPluginHook() {
+            super(null);
+        }
+
+        @Override
+        public boolean isCustomBlock(@NotNull Block block) {
+            return false;
+        }
+
+        @Override
+        public boolean isCustomBlock(@NotNull String customBlock) {
+            return "nexo:ruby_ore".equals(customBlock);
+        }
+
+        @Override
+        public boolean isCustomBlockOfType(@NotNull Block block, @NotNull String customBlockType) {
+            return false;
+        }
+
+        @Override
+        public void placeCustomBlock(@NotNull Location location, @NotNull String blockId) {
+        }
+
+        @NotNull
+        @Override
+        public List<ItemStack> drops(@NotNull Block block, @NotNull ItemStack itemToBreakWith, @Nullable Entity entityBreaking) {
+            return List.of();
+        }
+
+        @Override
+        public void playBlockDropEffects(@NotNull Block block) {
+        }
+
+        @Override
+        public void removeBlock(@NotNull Block block) {
+        }
+
+        @NotNull
+        @Override
+        public Optional<Set<String>> blockModels(@NotNull Block block) {
+            return Optional.empty();
+        }
+
+        @NotNull
+        @Override
+        public String blockName(@NotNull CustomBlockWrapper customBlockWrapper) {
+            return "Ruby Ore";
+        }
+    }
 
     @Nested
     @DisplayName("Material constructor")
     class MaterialConstructor {
 
         @Test
-        @DisplayName("Given a material, when constructing, then material() returns that material")
-        void material_returnsProvidedMaterial() {
+        @DisplayName("Given a material, when getting material, then returns that material")
+        void material_returnsProvidedMaterial_whenConstructedWithMaterial() {
             CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
             assertTrue(wrapper.material().isPresent());
             assertEquals(Material.STONE, wrapper.material().get());
         }
 
         @Test
-        @DisplayName("Given a material, when constructing, then customBlock() returns empty")
+        @DisplayName("Given a material, when getting customBlock, then returns empty")
         void customBlock_returnsEmpty_whenConstructedWithMaterial() {
             CustomBlockWrapper wrapper = materialWrapper(Material.DIAMOND_ORE);
             assertFalse(wrapper.customBlock().isPresent());
         }
     }
 
-    // ── Custom block accessors ──────────────────────────────────────────────
-
     @Nested
     @DisplayName("Custom block accessors")
     class CustomBlockAccessors {
 
         @Test
-        @DisplayName("Given a custom block wrapper, then customBlock() returns the custom block id")
-        void customBlock_returnsId() throws Exception {
+        @DisplayName("Given a custom block wrapper, when getting customBlock, then returns the custom block id")
+        void customBlock_returnsId_whenConstructedWithCustomBlock() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertTrue(wrapper.customBlock().isPresent());
             assertEquals("nexo:ruby_ore", wrapper.customBlock().get());
         }
 
         @Test
-        @DisplayName("Given a custom block wrapper, then material() returns empty")
-        void material_returnsEmpty_whenCustomBlock() throws Exception {
+        @DisplayName("Given a custom block wrapper, when getting material, then returns empty")
+        void material_returnsEmpty_whenConstructedWithCustomBlock() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertFalse(wrapper.material().isPresent());
         }
     }
-
-    // ── equals(Material) ────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(Material)")
@@ -94,27 +154,25 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given matching material, when comparing, then returns true")
-        void returnsTrue_whenMaterialMatches() {
+        void equals_returnsTrue_whenMaterialMatches() {
             CustomBlockWrapper wrapper = materialWrapper(Material.IRON_ORE);
             assertTrue(wrapper.equals(Material.IRON_ORE));
         }
 
         @Test
         @DisplayName("Given different material, when comparing, then returns false")
-        void returnsFalse_whenMaterialDiffers() {
+        void equals_returnsFalse_whenMaterialDiffers() {
             CustomBlockWrapper wrapper = materialWrapper(Material.IRON_ORE);
             assertFalse(wrapper.equals(Material.GOLD_ORE));
         }
 
         @Test
         @DisplayName("Given custom block wrapper, when comparing with any material, then returns false")
-        void returnsFalse_whenWrapperIsCustomBlock() throws Exception {
+        void equals_returnsFalse_whenWrapperIsCustomBlock() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertFalse(wrapper.equals(Material.DIAMOND_ORE));
         }
     }
-
-    // ── equals(String) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(String)")
@@ -122,27 +180,25 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given matching custom block id, when comparing, then returns true")
-        void returnsTrue_whenCustomBlockMatches() throws Exception {
+        void equals_returnsTrue_whenCustomBlockMatches() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertTrue(wrapper.equals("nexo:ruby_ore"));
         }
 
         @Test
         @DisplayName("Given different custom block id, when comparing, then returns false")
-        void returnsFalse_whenCustomBlockDiffers() throws Exception {
+        void equals_returnsFalse_whenCustomBlockDiffers() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertFalse(wrapper.equals("nexo:sapphire_ore"));
         }
 
         @Test
         @DisplayName("Given material wrapper, when comparing with any string, then returns false")
-        void returnsFalse_whenWrapperIsMaterial() {
+        void equals_returnsFalse_whenWrapperIsMaterial() {
             CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
             assertFalse(wrapper.equals("stone"));
         }
     }
-
-    // ── equals(CustomItemWrapper) ───────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(CustomItemWrapper)")
@@ -150,7 +206,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given block and item wrappers with same material, when comparing, then returns true")
-        void returnsTrue_whenBothMaterialsMatch() {
+        void equals_returnsTrue_whenBothMaterialsMatch() {
             CustomBlockWrapper blockWrapper = materialWrapper(Material.STONE);
             CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.STONE);
             assertTrue(blockWrapper.equals(itemWrapper));
@@ -158,7 +214,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given block and item wrappers with different materials, when comparing, then returns false")
-        void returnsFalse_whenMaterialsDiffer() {
+        void equals_returnsFalse_whenMaterialsDiffer() {
             CustomBlockWrapper blockWrapper = materialWrapper(Material.STONE);
             CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.DIRT);
             assertFalse(blockWrapper.equals(itemWrapper));
@@ -166,7 +222,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given custom block and custom item wrappers with same id, when comparing, then returns true")
-        void returnsTrue_whenBothCustomIdsMatch() throws Exception {
+        void equals_returnsTrue_whenBothCustomIdsMatch() throws Exception {
             CustomBlockWrapper blockWrapper = customBlockWrapper("nexo:ruby_ore");
             Field materialField = CustomItemWrapper.class.getDeclaredField("material");
             materialField.setAccessible(true);
@@ -180,14 +236,12 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given custom block and material item wrapper, when comparing, then returns false")
-        void returnsFalse_whenTypesAreMixed() throws Exception {
+        void equals_returnsFalse_whenTypesAreMixed() throws Exception {
             CustomBlockWrapper blockWrapper = customBlockWrapper("nexo:ruby_ore");
             CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.STONE);
             assertFalse(blockWrapper.equals(itemWrapper));
         }
     }
-
-    // ── equals(Object) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(Object)")
@@ -195,14 +249,21 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given same instance, when comparing, then returns true")
-        void returnsTrue_forSameInstance() {
+        void equals_returnsTrue_whenSameInstance() {
             CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
             assertEquals(wrapper, wrapper);
         }
 
         @Test
+        @DisplayName("Given null, when comparing, then returns false")
+        void equals_returnsFalse_whenComparedWithNull() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            assertNotEquals(null, wrapper);
+        }
+
+        @Test
         @DisplayName("Given two material wrappers with same material, when comparing as Object, then returns true")
-        void returnsTrue_whenMaterialWrappersMatch() {
+        void equals_returnsTrue_whenMaterialWrappersMatch() {
             CustomBlockWrapper a = materialWrapper(Material.STONE);
             CustomBlockWrapper b = materialWrapper(Material.STONE);
             assertEquals(a, b);
@@ -210,7 +271,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given two custom block wrappers with same id, when comparing as Object, then returns true")
-        void returnsTrue_whenCustomBlockWrappersMatch() throws Exception {
+        void equals_returnsTrue_whenCustomBlockWrappersMatch() throws Exception {
             CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
             CustomBlockWrapper b = customBlockWrapper("nexo:ruby_ore");
             assertEquals(a, b);
@@ -218,14 +279,14 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given block wrapper and different type, when comparing, then returns false")
-        void returnsFalse_whenComparedWithDifferentType() {
+        void equals_returnsFalse_whenComparedWithDifferentType() {
             CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
             assertNotEquals(wrapper, "not a wrapper");
         }
 
         @Test
         @DisplayName("Given one material and one custom wrapper, when comparing as Object, then returns false")
-        void returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
+        void equals_returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
             CustomBlockWrapper a = materialWrapper(Material.STONE);
             CustomBlockWrapper b = customBlockWrapper("nexo:stone");
             assertNotEquals(a, b);
@@ -233,7 +294,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given two different material wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenMaterialsDiffer() {
+        void equals_returnsFalse_whenMaterialsDiffer() {
             CustomBlockWrapper a = materialWrapper(Material.STONE);
             CustomBlockWrapper b = materialWrapper(Material.DIRT);
             assertNotEquals(a, b);
@@ -241,46 +302,58 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given two different custom block wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenCustomBlocksDiffer() throws Exception {
+        void equals_returnsFalse_whenCustomBlocksDiffer() throws Exception {
             CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
             CustomBlockWrapper b = customBlockWrapper("nexo:sapphire_ore");
             assertNotEquals(a, b);
         }
     }
 
-    // ── hashCode ────────────────────────────────────────────────────────────
-
     @Nested
     @DisplayName("hashCode")
     class HashCode {
 
         @Test
-        @DisplayName("Given two equal material wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualMaterialWrappers() {
+        @DisplayName("Given two equal material wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenMaterialWrappersAreEqual() {
             CustomBlockWrapper a = materialWrapper(Material.STONE);
             CustomBlockWrapper b = materialWrapper(Material.STONE);
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given two equal custom block wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualCustomBlockWrappers() throws Exception {
+        @DisplayName("Given two equal custom block wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenCustomBlockWrappersAreEqual() throws Exception {
             CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
             CustomBlockWrapper b = customBlockWrapper("nexo:ruby_ore");
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given material wrapper, then hashCode is consistent across calls")
-        void hashCode_isConsistent() {
+        @DisplayName("Given material wrapper, when getting hashCode multiple times, then value is consistent")
+        void hashCode_returnsSameValue_whenCalledMultipleTimes() {
             CustomBlockWrapper wrapper = materialWrapper(Material.DIAMOND_ORE);
             int first = wrapper.hashCode();
             int second = wrapper.hashCode();
             assertEquals(first, second);
         }
-    }
 
-    // ── blockName ───────────────────────────────────────────────────────────
+        @Test
+        @DisplayName("Given two unequal material wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenMaterialWrappersDiffer() {
+            CustomBlockWrapper a = materialWrapper(Material.STONE);
+            CustomBlockWrapper b = materialWrapper(Material.DIAMOND_ORE);
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two unequal custom block wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenCustomBlockWrappersDiffer() throws Exception {
+            CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
+            CustomBlockWrapper b = customBlockWrapper("nexo:sapphire_ore");
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+    }
 
     @Nested
     @DisplayName("blockName")
@@ -288,13 +361,19 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given custom block wrapper with no hooks registered, when getting blockName, then returns Missing Block")
-        void returnsMissingBlock_whenNoHooksRegistered() throws Exception {
+        void blockName_returnsMissingBlock_whenNoHooksRegistered() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             assertEquals("Missing Block", wrapper.blockName());
         }
-    }
 
-    // ── toString ─────────────────────────────────────────────────────────────
+        @Test
+        @DisplayName("Given custom block wrapper with a hook registered, when getting blockName, then returns hook-provided name")
+        void blockName_returnsHookProvidedName_whenHookIsRegistered() throws Exception {
+            RegistryAccess.registryAccess().registry(RegistryKey.PLUGIN_HOOK).register(new TestCustomBlockPluginHook());
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertEquals("Ruby Ore", wrapper.blockName());
+        }
+    }
 
     @Nested
     @DisplayName("toString")
@@ -302,7 +381,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given material wrapper, when calling toString, then contains material name")
-        void containsMaterialName_forMaterialWrapper() {
+        void toString_containsMaterialName_whenMaterialWrapper() {
             CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
             String result = wrapper.toString();
             assertTrue(result.contains("STONE"), "Expected toString to contain STONE, got: " + result);
@@ -311,7 +390,7 @@ class CustomBlockWrapperTest {
 
         @Test
         @DisplayName("Given custom block wrapper, when calling toString, then contains custom block id")
-        void containsCustomBlockId_forCustomBlockWrapper() throws Exception {
+        void toString_containsCustomBlockId_whenCustomBlockWrapper() throws Exception {
             CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
             String result = wrapper.toString();
             assertTrue(result.contains("nexo:ruby_ore"), "Expected toString to contain nexo:ruby_ore, got: " + result);

--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomBlockWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomBlockWrapperTest.java
@@ -1,0 +1,321 @@
+package com.diamonddagger590.mccore.util.item;
+
+import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CustomBlockWrapperTest {
+
+    @BeforeEach
+    void setUp() {
+        RegistryResetExtension.setupRegistry();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RegistryResetExtension.resetRegistry();
+    }
+
+    private static CustomBlockWrapper materialWrapper(Material material) {
+        return new CustomBlockWrapper(material);
+    }
+
+    private static CustomBlockWrapper customBlockWrapper(String customBlock) throws Exception {
+        CustomBlockWrapper wrapper = new CustomBlockWrapper(Material.STONE);
+        Field materialField = CustomBlockWrapper.class.getDeclaredField("material");
+        materialField.setAccessible(true);
+        materialField.set(wrapper, null);
+        Field customBlockField = CustomBlockWrapper.class.getDeclaredField("customBlock");
+        customBlockField.setAccessible(true);
+        customBlockField.set(wrapper, customBlock);
+        return wrapper;
+    }
+
+    // ── Material constructor ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Material constructor")
+    class MaterialConstructor {
+
+        @Test
+        @DisplayName("Given a material, when constructing, then material() returns that material")
+        void material_returnsProvidedMaterial() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            assertTrue(wrapper.material().isPresent());
+            assertEquals(Material.STONE, wrapper.material().get());
+        }
+
+        @Test
+        @DisplayName("Given a material, when constructing, then customBlock() returns empty")
+        void customBlock_returnsEmpty_whenConstructedWithMaterial() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.DIAMOND_ORE);
+            assertFalse(wrapper.customBlock().isPresent());
+        }
+    }
+
+    // ── Custom block accessors ──────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Custom block accessors")
+    class CustomBlockAccessors {
+
+        @Test
+        @DisplayName("Given a custom block wrapper, then customBlock() returns the custom block id")
+        void customBlock_returnsId() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertTrue(wrapper.customBlock().isPresent());
+            assertEquals("nexo:ruby_ore", wrapper.customBlock().get());
+        }
+
+        @Test
+        @DisplayName("Given a custom block wrapper, then material() returns empty")
+        void material_returnsEmpty_whenCustomBlock() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertFalse(wrapper.material().isPresent());
+        }
+    }
+
+    // ── equals(Material) ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(Material)")
+    class EqualsMaterial {
+
+        @Test
+        @DisplayName("Given matching material, when comparing, then returns true")
+        void returnsTrue_whenMaterialMatches() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.IRON_ORE);
+            assertTrue(wrapper.equals(Material.IRON_ORE));
+        }
+
+        @Test
+        @DisplayName("Given different material, when comparing, then returns false")
+        void returnsFalse_whenMaterialDiffers() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.IRON_ORE);
+            assertFalse(wrapper.equals(Material.GOLD_ORE));
+        }
+
+        @Test
+        @DisplayName("Given custom block wrapper, when comparing with any material, then returns false")
+        void returnsFalse_whenWrapperIsCustomBlock() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertFalse(wrapper.equals(Material.DIAMOND_ORE));
+        }
+    }
+
+    // ── equals(String) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(String)")
+    class EqualsString {
+
+        @Test
+        @DisplayName("Given matching custom block id, when comparing, then returns true")
+        void returnsTrue_whenCustomBlockMatches() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertTrue(wrapper.equals("nexo:ruby_ore"));
+        }
+
+        @Test
+        @DisplayName("Given different custom block id, when comparing, then returns false")
+        void returnsFalse_whenCustomBlockDiffers() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertFalse(wrapper.equals("nexo:sapphire_ore"));
+        }
+
+        @Test
+        @DisplayName("Given material wrapper, when comparing with any string, then returns false")
+        void returnsFalse_whenWrapperIsMaterial() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            assertFalse(wrapper.equals("stone"));
+        }
+    }
+
+    // ── equals(CustomItemWrapper) ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(CustomItemWrapper)")
+    class EqualsCustomItemWrapper {
+
+        @Test
+        @DisplayName("Given block and item wrappers with same material, when comparing, then returns true")
+        void returnsTrue_whenBothMaterialsMatch() {
+            CustomBlockWrapper blockWrapper = materialWrapper(Material.STONE);
+            CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.STONE);
+            assertTrue(blockWrapper.equals(itemWrapper));
+        }
+
+        @Test
+        @DisplayName("Given block and item wrappers with different materials, when comparing, then returns false")
+        void returnsFalse_whenMaterialsDiffer() {
+            CustomBlockWrapper blockWrapper = materialWrapper(Material.STONE);
+            CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.DIRT);
+            assertFalse(blockWrapper.equals(itemWrapper));
+        }
+
+        @Test
+        @DisplayName("Given custom block and custom item wrappers with same id, when comparing, then returns true")
+        void returnsTrue_whenBothCustomIdsMatch() throws Exception {
+            CustomBlockWrapper blockWrapper = customBlockWrapper("nexo:ruby_ore");
+            Field materialField = CustomItemWrapper.class.getDeclaredField("material");
+            materialField.setAccessible(true);
+            Field customItemField = CustomItemWrapper.class.getDeclaredField("customItem");
+            customItemField.setAccessible(true);
+            CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.AIR);
+            materialField.set(itemWrapper, null);
+            customItemField.set(itemWrapper, "nexo:ruby_ore");
+            assertTrue(blockWrapper.equals(itemWrapper));
+        }
+
+        @Test
+        @DisplayName("Given custom block and material item wrapper, when comparing, then returns false")
+        void returnsFalse_whenTypesAreMixed() throws Exception {
+            CustomBlockWrapper blockWrapper = customBlockWrapper("nexo:ruby_ore");
+            CustomItemWrapper itemWrapper = new CustomItemWrapper(Material.STONE);
+            assertFalse(blockWrapper.equals(itemWrapper));
+        }
+    }
+
+    // ── equals(Object) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(Object)")
+    class EqualsObject {
+
+        @Test
+        @DisplayName("Given same instance, when comparing, then returns true")
+        void returnsTrue_forSameInstance() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            assertEquals(wrapper, wrapper);
+        }
+
+        @Test
+        @DisplayName("Given two material wrappers with same material, when comparing as Object, then returns true")
+        void returnsTrue_whenMaterialWrappersMatch() {
+            CustomBlockWrapper a = materialWrapper(Material.STONE);
+            CustomBlockWrapper b = materialWrapper(Material.STONE);
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two custom block wrappers with same id, when comparing as Object, then returns true")
+        void returnsTrue_whenCustomBlockWrappersMatch() throws Exception {
+            CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
+            CustomBlockWrapper b = customBlockWrapper("nexo:ruby_ore");
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given block wrapper and different type, when comparing, then returns false")
+        void returnsFalse_whenComparedWithDifferentType() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            assertNotEquals(wrapper, "not a wrapper");
+        }
+
+        @Test
+        @DisplayName("Given one material and one custom wrapper, when comparing as Object, then returns false")
+        void returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
+            CustomBlockWrapper a = materialWrapper(Material.STONE);
+            CustomBlockWrapper b = customBlockWrapper("nexo:stone");
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different material wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenMaterialsDiffer() {
+            CustomBlockWrapper a = materialWrapper(Material.STONE);
+            CustomBlockWrapper b = materialWrapper(Material.DIRT);
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different custom block wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenCustomBlocksDiffer() throws Exception {
+            CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
+            CustomBlockWrapper b = customBlockWrapper("nexo:sapphire_ore");
+            assertNotEquals(a, b);
+        }
+    }
+
+    // ── hashCode ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("hashCode")
+    class HashCode {
+
+        @Test
+        @DisplayName("Given two equal material wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualMaterialWrappers() {
+            CustomBlockWrapper a = materialWrapper(Material.STONE);
+            CustomBlockWrapper b = materialWrapper(Material.STONE);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two equal custom block wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualCustomBlockWrappers() throws Exception {
+            CustomBlockWrapper a = customBlockWrapper("nexo:ruby_ore");
+            CustomBlockWrapper b = customBlockWrapper("nexo:ruby_ore");
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given material wrapper, then hashCode is consistent across calls")
+        void hashCode_isConsistent() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.DIAMOND_ORE);
+            int first = wrapper.hashCode();
+            int second = wrapper.hashCode();
+            assertEquals(first, second);
+        }
+    }
+
+    // ── blockName ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("blockName")
+    class BlockName {
+
+        @Test
+        @DisplayName("Given custom block wrapper with no hooks registered, when getting blockName, then returns Missing Block")
+        void returnsMissingBlock_whenNoHooksRegistered() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            assertEquals("Missing Block", wrapper.blockName());
+        }
+    }
+
+    // ── toString ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("toString")
+    class ToString {
+
+        @Test
+        @DisplayName("Given material wrapper, when calling toString, then contains material name")
+        void containsMaterialName_forMaterialWrapper() {
+            CustomBlockWrapper wrapper = materialWrapper(Material.STONE);
+            String result = wrapper.toString();
+            assertTrue(result.contains("STONE"), "Expected toString to contain STONE, got: " + result);
+            assertTrue(result.contains("customBlock=null"), "Expected customBlock=null, got: " + result);
+        }
+
+        @Test
+        @DisplayName("Given custom block wrapper, when calling toString, then contains custom block id")
+        void containsCustomBlockId_forCustomBlockWrapper() throws Exception {
+            CustomBlockWrapper wrapper = customBlockWrapper("nexo:ruby_ore");
+            String result = wrapper.toString();
+            assertTrue(result.contains("nexo:ruby_ore"), "Expected toString to contain nexo:ruby_ore, got: " + result);
+            assertTrue(result.contains("material=null"), "Expected material=null, got: " + result);
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomEntityWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomEntityWrapperTest.java
@@ -1,7 +1,14 @@
 package com.diamonddagger590.mccore.util.item;
 
+import com.diamonddagger590.mccore.CorePlugin;
+import com.diamonddagger590.mccore.external.common.CustomEntityHook;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.registry.plugin.PluginHook;
 import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +16,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,51 +52,79 @@ class CustomEntityWrapperTest {
         return wrapper;
     }
 
-    // ── EntityType constructor ──────────────────────────────────────────────
+    static class TestCustomEntityPluginHook extends PluginHook<CorePlugin> implements CustomEntityHook {
+
+        TestCustomEntityPluginHook() {
+            super(null);
+        }
+
+        @Override
+        public boolean isCustomEntity(@NotNull UUID uuid) {
+            return false;
+        }
+
+        @Override
+        public boolean isCustomEntity(@NotNull String customEntity) {
+            return "mythicmobs:fire_dragon".equals(customEntity);
+        }
+
+        @Override
+        public boolean isCustomEntityOfType(@NotNull UUID uuid, @NotNull String customEntityType) {
+            return false;
+        }
+
+        @NotNull
+        @Override
+        public Optional<Set<String>> entityModels(@NotNull Entity entity) {
+            return Optional.empty();
+        }
+
+        @NotNull
+        @Override
+        public String entityName(@NotNull CustomEntityWrapper customEntityWrapper) {
+            return "Fire Dragon";
+        }
+    }
 
     @Nested
     @DisplayName("EntityType constructor")
     class EntityTypeConstructor {
 
         @Test
-        @DisplayName("Given an entity type, when constructing, then entityType() returns that type")
-        void entityType_returnsProvidedType() {
+        @DisplayName("Given an entity type, when getting entityType, then returns that type")
+        void entityType_returnsProvidedType_whenConstructedWithEntityType() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
             assertTrue(wrapper.entityType().isPresent());
             assertEquals(EntityType.ZOMBIE, wrapper.entityType().get());
         }
 
         @Test
-        @DisplayName("Given an entity type, when constructing, then customEntity() returns empty")
+        @DisplayName("Given an entity type, when getting customEntity, then returns empty")
         void customEntity_returnsEmpty_whenConstructedWithEntityType() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
             assertFalse(wrapper.customEntity().isPresent());
         }
     }
 
-    // ── Custom entity accessors ─────────────────────────────────────────────
-
     @Nested
     @DisplayName("Custom entity accessors")
     class CustomEntityAccessors {
 
         @Test
-        @DisplayName("Given a custom entity wrapper, then customEntity() returns the custom entity id")
-        void customEntity_returnsId() throws Exception {
+        @DisplayName("Given a custom entity wrapper, when getting customEntity, then returns the custom entity id")
+        void customEntity_returnsId_whenConstructedWithCustomEntity() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertTrue(wrapper.customEntity().isPresent());
             assertEquals("mythicmobs:fire_dragon", wrapper.customEntity().get());
         }
 
         @Test
-        @DisplayName("Given a custom entity wrapper, then entityType() returns empty")
-        void entityType_returnsEmpty_whenCustomEntity() throws Exception {
+        @DisplayName("Given a custom entity wrapper, when getting entityType, then returns empty")
+        void entityType_returnsEmpty_whenConstructedWithCustomEntity() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertFalse(wrapper.entityType().isPresent());
         }
     }
-
-    // ── equals(EntityType) ──────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(EntityType)")
@@ -94,27 +132,25 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given matching entity type, when comparing, then returns true")
-        void returnsTrue_whenEntityTypeMatches() {
+        void equals_returnsTrue_whenEntityTypeMatches() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.SKELETON);
             assertTrue(wrapper.equals(EntityType.SKELETON));
         }
 
         @Test
         @DisplayName("Given different entity type, when comparing, then returns false")
-        void returnsFalse_whenEntityTypeDiffers() {
+        void equals_returnsFalse_whenEntityTypeDiffers() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.SKELETON);
             assertFalse(wrapper.equals(EntityType.ZOMBIE));
         }
 
         @Test
         @DisplayName("Given custom entity wrapper, when comparing with any entity type, then returns false")
-        void returnsFalse_whenWrapperIsCustomEntity() throws Exception {
+        void equals_returnsFalse_whenWrapperIsCustomEntity() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertFalse(wrapper.equals(EntityType.ENDER_DRAGON));
         }
     }
-
-    // ── equals(String) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(String)")
@@ -122,27 +158,25 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given matching custom entity id, when comparing, then returns true")
-        void returnsTrue_whenCustomEntityMatches() throws Exception {
+        void equals_returnsTrue_whenCustomEntityMatches() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertTrue(wrapper.equals("mythicmobs:fire_dragon"));
         }
 
         @Test
         @DisplayName("Given different custom entity id, when comparing, then returns false")
-        void returnsFalse_whenCustomEntityDiffers() throws Exception {
+        void equals_returnsFalse_whenCustomEntityDiffers() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertFalse(wrapper.equals("mythicmobs:ice_dragon"));
         }
 
         @Test
         @DisplayName("Given entity type wrapper, when comparing with any string, then returns false")
-        void returnsFalse_whenWrapperIsEntityType() {
+        void equals_returnsFalse_whenWrapperIsEntityType() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
             assertFalse(wrapper.equals("zombie"));
         }
     }
-
-    // ── equals(CustomEntityWrapper) ─────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(CustomEntityWrapper)")
@@ -150,7 +184,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two entity type wrappers with same type, when comparing, then returns true")
-        void returnsTrue_whenBothEntityTypesMatch() {
+        void equals_returnsTrue_whenBothEntityTypesMatch() {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper b = entityTypeWrapper(EntityType.ZOMBIE);
             assertTrue(a.equals(b));
@@ -158,7 +192,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two entity type wrappers with different types, when comparing, then returns false")
-        void returnsFalse_whenEntityTypesDiffer() {
+        void equals_returnsFalse_whenEntityTypesDiffer() {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper b = entityTypeWrapper(EntityType.SKELETON);
             assertFalse(a.equals(b));
@@ -166,7 +200,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two custom entity wrappers with same id, when comparing, then returns true")
-        void returnsTrue_whenBothCustomEntitiesMatch() throws Exception {
+        void equals_returnsTrue_whenBothCustomEntitiesMatch() throws Exception {
             CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
             assertTrue(a.equals(b));
@@ -174,7 +208,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two custom entity wrappers with different ids, when comparing, then returns false")
-        void returnsFalse_whenCustomEntitiesDiffer() throws Exception {
+        void equals_returnsFalse_whenCustomEntitiesDiffer() throws Exception {
             CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:ice_dragon");
             assertFalse(a.equals(b));
@@ -182,14 +216,12 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given entity type wrapper and custom entity wrapper, when comparing, then returns false")
-        void returnsFalse_whenTypesAreMixed() throws Exception {
+        void equals_returnsFalse_whenTypesAreMixed() throws Exception {
             CustomEntityWrapper entityBased = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper customBased = customEntityWrapper("mythicmobs:zombie");
             assertFalse(entityBased.equals(customBased));
         }
     }
-
-    // ── equals(Object) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(Object)")
@@ -197,14 +229,21 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given same instance, when comparing, then returns true")
-        void returnsTrue_forSameInstance() {
+        void equals_returnsTrue_whenSameInstance() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
             assertEquals(wrapper, wrapper);
         }
 
         @Test
+        @DisplayName("Given null, when comparing, then returns false")
+        void equals_returnsFalse_whenComparedWithNull() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
+            assertNotEquals(null, wrapper);
+        }
+
+        @Test
         @DisplayName("Given two entity type wrappers with same type, when comparing as Object, then returns true")
-        void returnsTrue_whenEntityTypeWrappersMatch() {
+        void equals_returnsTrue_whenEntityTypeWrappersMatch() {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.CREEPER);
             CustomEntityWrapper b = entityTypeWrapper(EntityType.CREEPER);
             assertEquals(a, b);
@@ -212,7 +251,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two custom entity wrappers with same id, when comparing as Object, then returns true")
-        void returnsTrue_whenCustomEntityWrappersMatch() throws Exception {
+        void equals_returnsTrue_whenCustomEntityWrappersMatch() throws Exception {
             CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
             assertEquals(a, b);
@@ -220,14 +259,14 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given entity wrapper and different type, when comparing, then returns false")
-        void returnsFalse_whenComparedWithDifferentType() {
+        void equals_returnsFalse_whenComparedWithDifferentType() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
             assertNotEquals(wrapper, "not a wrapper");
         }
 
         @Test
         @DisplayName("Given one entity type and one custom wrapper, when comparing as Object, then returns false")
-        void returnsFalse_whenOneIsEntityTypeAndOtherIsCustom() throws Exception {
+        void equals_returnsFalse_whenOneIsEntityTypeAndOtherIsCustom() throws Exception {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:zombie");
             assertNotEquals(a, b);
@@ -235,7 +274,7 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two different entity type wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenEntityTypesDiffer() {
+        void equals_returnsFalse_whenEntityTypesDiffer() {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper b = entityTypeWrapper(EntityType.SKELETON);
             assertNotEquals(a, b);
@@ -243,46 +282,58 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given two different custom entity wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenCustomEntitiesDiffer() throws Exception {
+        void equals_returnsFalse_whenCustomEntitiesDiffer() throws Exception {
             CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:ice_dragon");
             assertNotEquals(a, b);
         }
     }
 
-    // ── hashCode ────────────────────────────────────────────────────────────
-
     @Nested
     @DisplayName("hashCode")
     class HashCode {
 
         @Test
-        @DisplayName("Given two equal entity type wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualEntityTypeWrappers() {
+        @DisplayName("Given two equal entity type wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenEntityTypeWrappersAreEqual() {
             CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
             CustomEntityWrapper b = entityTypeWrapper(EntityType.ZOMBIE);
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given two equal custom entity wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualCustomEntityWrappers() throws Exception {
+        @DisplayName("Given two equal custom entity wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenCustomEntityWrappersAreEqual() throws Exception {
             CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
             CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given entity type wrapper, then hashCode is consistent across calls")
-        void hashCode_isConsistent() {
+        @DisplayName("Given entity type wrapper, when getting hashCode multiple times, then value is consistent")
+        void hashCode_returnsSameValue_whenCalledMultipleTimes() {
             CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
             int first = wrapper.hashCode();
             int second = wrapper.hashCode();
             assertEquals(first, second);
         }
-    }
 
-    // ── entityName ──────────────────────────────────────────────────────────
+        @Test
+        @DisplayName("Given two unequal entity type wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenEntityTypeWrappersDiffer() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.SKELETON);
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two unequal custom entity wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenCustomEntityWrappersDiffer() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:ice_dragon");
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+    }
 
     @Nested
     @DisplayName("entityName")
@@ -290,9 +341,17 @@ class CustomEntityWrapperTest {
 
         @Test
         @DisplayName("Given custom entity wrapper with no hooks registered, when getting entityName, then returns Unknown")
-        void returnsUnknown_whenNoHooksRegistered() throws Exception {
+        void entityName_returnsUnknown_whenNoHooksRegistered() throws Exception {
             CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
             assertEquals("Unknown", wrapper.entityName());
+        }
+
+        @Test
+        @DisplayName("Given custom entity wrapper with a hook registered, when getting entityName, then returns hook-provided name")
+        void entityName_returnsHookProvidedName_whenHookIsRegistered() throws Exception {
+            RegistryAccess.registryAccess().registry(RegistryKey.PLUGIN_HOOK).register(new TestCustomEntityPluginHook());
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertEquals("Fire Dragon", wrapper.entityName());
         }
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomEntityWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomEntityWrapperTest.java
@@ -1,0 +1,298 @@
+package com.diamonddagger590.mccore.util.item;
+
+import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.entity.EntityType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CustomEntityWrapperTest {
+
+    @BeforeEach
+    void setUp() {
+        RegistryResetExtension.setupRegistry();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RegistryResetExtension.resetRegistry();
+    }
+
+    private static CustomEntityWrapper entityTypeWrapper(EntityType entityType) {
+        return new CustomEntityWrapper(entityType);
+    }
+
+    private static CustomEntityWrapper customEntityWrapper(String customEntity) throws Exception {
+        CustomEntityWrapper wrapper = new CustomEntityWrapper(EntityType.ZOMBIE);
+        Field entityTypeField = CustomEntityWrapper.class.getDeclaredField("entityType");
+        entityTypeField.setAccessible(true);
+        entityTypeField.set(wrapper, null);
+        Field customEntityField = CustomEntityWrapper.class.getDeclaredField("customEntity");
+        customEntityField.setAccessible(true);
+        customEntityField.set(wrapper, customEntity);
+        return wrapper;
+    }
+
+    // ── EntityType constructor ──────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("EntityType constructor")
+    class EntityTypeConstructor {
+
+        @Test
+        @DisplayName("Given an entity type, when constructing, then entityType() returns that type")
+        void entityType_returnsProvidedType() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
+            assertTrue(wrapper.entityType().isPresent());
+            assertEquals(EntityType.ZOMBIE, wrapper.entityType().get());
+        }
+
+        @Test
+        @DisplayName("Given an entity type, when constructing, then customEntity() returns empty")
+        void customEntity_returnsEmpty_whenConstructedWithEntityType() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
+            assertFalse(wrapper.customEntity().isPresent());
+        }
+    }
+
+    // ── Custom entity accessors ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Custom entity accessors")
+    class CustomEntityAccessors {
+
+        @Test
+        @DisplayName("Given a custom entity wrapper, then customEntity() returns the custom entity id")
+        void customEntity_returnsId() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertTrue(wrapper.customEntity().isPresent());
+            assertEquals("mythicmobs:fire_dragon", wrapper.customEntity().get());
+        }
+
+        @Test
+        @DisplayName("Given a custom entity wrapper, then entityType() returns empty")
+        void entityType_returnsEmpty_whenCustomEntity() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertFalse(wrapper.entityType().isPresent());
+        }
+    }
+
+    // ── equals(EntityType) ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(EntityType)")
+    class EqualsEntityType {
+
+        @Test
+        @DisplayName("Given matching entity type, when comparing, then returns true")
+        void returnsTrue_whenEntityTypeMatches() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.SKELETON);
+            assertTrue(wrapper.equals(EntityType.SKELETON));
+        }
+
+        @Test
+        @DisplayName("Given different entity type, when comparing, then returns false")
+        void returnsFalse_whenEntityTypeDiffers() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.SKELETON);
+            assertFalse(wrapper.equals(EntityType.ZOMBIE));
+        }
+
+        @Test
+        @DisplayName("Given custom entity wrapper, when comparing with any entity type, then returns false")
+        void returnsFalse_whenWrapperIsCustomEntity() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertFalse(wrapper.equals(EntityType.ENDER_DRAGON));
+        }
+    }
+
+    // ── equals(String) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(String)")
+    class EqualsString {
+
+        @Test
+        @DisplayName("Given matching custom entity id, when comparing, then returns true")
+        void returnsTrue_whenCustomEntityMatches() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertTrue(wrapper.equals("mythicmobs:fire_dragon"));
+        }
+
+        @Test
+        @DisplayName("Given different custom entity id, when comparing, then returns false")
+        void returnsFalse_whenCustomEntityDiffers() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertFalse(wrapper.equals("mythicmobs:ice_dragon"));
+        }
+
+        @Test
+        @DisplayName("Given entity type wrapper, when comparing with any string, then returns false")
+        void returnsFalse_whenWrapperIsEntityType() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
+            assertFalse(wrapper.equals("zombie"));
+        }
+    }
+
+    // ── equals(CustomEntityWrapper) ─────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(CustomEntityWrapper)")
+    class EqualsWrapper {
+
+        @Test
+        @DisplayName("Given two entity type wrappers with same type, when comparing, then returns true")
+        void returnsTrue_whenBothEntityTypesMatch() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.ZOMBIE);
+            assertTrue(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two entity type wrappers with different types, when comparing, then returns false")
+        void returnsFalse_whenEntityTypesDiffer() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.SKELETON);
+            assertFalse(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two custom entity wrappers with same id, when comparing, then returns true")
+        void returnsTrue_whenBothCustomEntitiesMatch() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
+            assertTrue(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two custom entity wrappers with different ids, when comparing, then returns false")
+        void returnsFalse_whenCustomEntitiesDiffer() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:ice_dragon");
+            assertFalse(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given entity type wrapper and custom entity wrapper, when comparing, then returns false")
+        void returnsFalse_whenTypesAreMixed() throws Exception {
+            CustomEntityWrapper entityBased = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper customBased = customEntityWrapper("mythicmobs:zombie");
+            assertFalse(entityBased.equals(customBased));
+        }
+    }
+
+    // ── equals(Object) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(Object)")
+    class EqualsObject {
+
+        @Test
+        @DisplayName("Given same instance, when comparing, then returns true")
+        void returnsTrue_forSameInstance() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
+            assertEquals(wrapper, wrapper);
+        }
+
+        @Test
+        @DisplayName("Given two entity type wrappers with same type, when comparing as Object, then returns true")
+        void returnsTrue_whenEntityTypeWrappersMatch() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.CREEPER);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.CREEPER);
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two custom entity wrappers with same id, when comparing as Object, then returns true")
+        void returnsTrue_whenCustomEntityWrappersMatch() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given entity wrapper and different type, when comparing, then returns false")
+        void returnsFalse_whenComparedWithDifferentType() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.ZOMBIE);
+            assertNotEquals(wrapper, "not a wrapper");
+        }
+
+        @Test
+        @DisplayName("Given one entity type and one custom wrapper, when comparing as Object, then returns false")
+        void returnsFalse_whenOneIsEntityTypeAndOtherIsCustom() throws Exception {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:zombie");
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different entity type wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenEntityTypesDiffer() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.SKELETON);
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different custom entity wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenCustomEntitiesDiffer() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:ice_dragon");
+            assertNotEquals(a, b);
+        }
+    }
+
+    // ── hashCode ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("hashCode")
+    class HashCode {
+
+        @Test
+        @DisplayName("Given two equal entity type wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualEntityTypeWrappers() {
+            CustomEntityWrapper a = entityTypeWrapper(EntityType.ZOMBIE);
+            CustomEntityWrapper b = entityTypeWrapper(EntityType.ZOMBIE);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two equal custom entity wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualCustomEntityWrappers() throws Exception {
+            CustomEntityWrapper a = customEntityWrapper("mythicmobs:fire_dragon");
+            CustomEntityWrapper b = customEntityWrapper("mythicmobs:fire_dragon");
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given entity type wrapper, then hashCode is consistent across calls")
+        void hashCode_isConsistent() {
+            CustomEntityWrapper wrapper = entityTypeWrapper(EntityType.CREEPER);
+            int first = wrapper.hashCode();
+            int second = wrapper.hashCode();
+            assertEquals(first, second);
+        }
+    }
+
+    // ── entityName ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("entityName")
+    class EntityName {
+
+        @Test
+        @DisplayName("Given custom entity wrapper with no hooks registered, when getting entityName, then returns Unknown")
+        void returnsUnknown_whenNoHooksRegistered() throws Exception {
+            CustomEntityWrapper wrapper = customEntityWrapper("mythicmobs:fire_dragon");
+            assertEquals("Unknown", wrapper.entityName());
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomItemWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomItemWrapperTest.java
@@ -1,0 +1,298 @@
+package com.diamonddagger590.mccore.util.item;
+
+import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CustomItemWrapperTest {
+
+    @BeforeEach
+    void setUp() {
+        RegistryResetExtension.setupRegistry();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RegistryResetExtension.resetRegistry();
+    }
+
+    private static CustomItemWrapper materialWrapper(Material material) {
+        return new CustomItemWrapper(material);
+    }
+
+    private static CustomItemWrapper customItemWrapper(String customItem) throws Exception {
+        CustomItemWrapper wrapper = new CustomItemWrapper(Material.AIR);
+        Field materialField = CustomItemWrapper.class.getDeclaredField("material");
+        materialField.setAccessible(true);
+        materialField.set(wrapper, null);
+        Field customItemField = CustomItemWrapper.class.getDeclaredField("customItem");
+        customItemField.setAccessible(true);
+        customItemField.set(wrapper, customItem);
+        return wrapper;
+    }
+
+    // ── Material constructor ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Material constructor")
+    class MaterialConstructor {
+
+        @Test
+        @DisplayName("Given a material, when constructing, then material() returns that material")
+        void material_returnsProvidedMaterial() {
+            CustomItemWrapper wrapper = materialWrapper(Material.DIAMOND);
+            assertTrue(wrapper.material().isPresent());
+            assertEquals(Material.DIAMOND, wrapper.material().get());
+        }
+
+        @Test
+        @DisplayName("Given a material, when constructing, then customItem() returns empty")
+        void customItem_returnsEmpty_whenConstructedWithMaterial() {
+            CustomItemWrapper wrapper = materialWrapper(Material.STONE);
+            assertFalse(wrapper.customItem().isPresent());
+        }
+    }
+
+    // ── Custom item wrapper (reflective construction) ───────────────────────
+
+    @Nested
+    @DisplayName("Custom item accessors")
+    class CustomItemAccessors {
+
+        @Test
+        @DisplayName("Given a custom item wrapper, then customItem() returns the custom item id")
+        void customItem_returnsId() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertTrue(wrapper.customItem().isPresent());
+            assertEquals("nexo:ruby_sword", wrapper.customItem().get());
+        }
+
+        @Test
+        @DisplayName("Given a custom item wrapper, then material() returns empty")
+        void material_returnsEmpty_whenCustomItem() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertFalse(wrapper.material().isPresent());
+        }
+    }
+
+    // ── equals(Material) ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(Material)")
+    class EqualsMaterial {
+
+        @Test
+        @DisplayName("Given matching material, when comparing, then returns true")
+        void returnsTrue_whenMaterialMatches() {
+            CustomItemWrapper wrapper = materialWrapper(Material.IRON_INGOT);
+            assertTrue(wrapper.equals(Material.IRON_INGOT));
+        }
+
+        @Test
+        @DisplayName("Given different material, when comparing, then returns false")
+        void returnsFalse_whenMaterialDiffers() {
+            CustomItemWrapper wrapper = materialWrapper(Material.IRON_INGOT);
+            assertFalse(wrapper.equals(Material.GOLD_INGOT));
+        }
+
+        @Test
+        @DisplayName("Given custom item wrapper, when comparing with any material, then returns false")
+        void returnsFalse_whenWrapperIsCustomItem() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby");
+            assertFalse(wrapper.equals(Material.DIAMOND));
+        }
+    }
+
+    // ── equals(String) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(String)")
+    class EqualsString {
+
+        @Test
+        @DisplayName("Given matching custom item id, when comparing, then returns true")
+        void returnsTrue_whenCustomItemMatches() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertTrue(wrapper.equals("nexo:ruby_sword"));
+        }
+
+        @Test
+        @DisplayName("Given different custom item id, when comparing, then returns false")
+        void returnsFalse_whenCustomItemDiffers() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertFalse(wrapper.equals("nexo:diamond_sword"));
+        }
+
+        @Test
+        @DisplayName("Given material wrapper, when comparing with any string, then returns false")
+        void returnsFalse_whenWrapperIsMaterial() {
+            CustomItemWrapper wrapper = materialWrapper(Material.STONE);
+            assertFalse(wrapper.equals("stone"));
+        }
+    }
+
+    // ── equals(CustomItemWrapper) ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(CustomItemWrapper)")
+    class EqualsWrapper {
+
+        @Test
+        @DisplayName("Given two material wrappers with same material, when comparing, then returns true")
+        void returnsTrue_whenBothMaterialsMatch() {
+            CustomItemWrapper a = materialWrapper(Material.DIAMOND);
+            CustomItemWrapper b = materialWrapper(Material.DIAMOND);
+            assertTrue(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two material wrappers with different materials, when comparing, then returns false")
+        void returnsFalse_whenMaterialsDiffer() {
+            CustomItemWrapper a = materialWrapper(Material.DIAMOND);
+            CustomItemWrapper b = materialWrapper(Material.EMERALD);
+            assertFalse(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two custom item wrappers with same id, when comparing, then returns true")
+        void returnsTrue_whenBothCustomItemsMatch() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:ruby");
+            assertTrue(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given two custom item wrappers with different ids, when comparing, then returns false")
+        void returnsFalse_whenCustomItemsDiffer() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:sapphire");
+            assertFalse(a.equals(b));
+        }
+
+        @Test
+        @DisplayName("Given material wrapper and custom item wrapper, when comparing, then returns false")
+        void returnsFalse_whenTypesAreMixed() throws Exception {
+            CustomItemWrapper materialBased = materialWrapper(Material.STONE);
+            CustomItemWrapper customBased = customItemWrapper("nexo:stone");
+            assertFalse(materialBased.equals(customBased));
+        }
+    }
+
+    // ── equals(Object) ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("equals(Object)")
+    class EqualsObject {
+
+        @Test
+        @DisplayName("Given same instance, when comparing, then returns true")
+        void returnsTrue_forSameInstance() {
+            CustomItemWrapper wrapper = materialWrapper(Material.STONE);
+            assertEquals(wrapper, wrapper);
+        }
+
+        @Test
+        @DisplayName("Given two material wrappers with same material, when comparing as Object, then returns true")
+        void returnsTrue_whenMaterialWrappersMatch() {
+            CustomItemWrapper a = materialWrapper(Material.STONE);
+            CustomItemWrapper b = materialWrapper(Material.STONE);
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two custom item wrappers with same id, when comparing as Object, then returns true")
+        void returnsTrue_whenCustomItemWrappersMatch() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:ruby");
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given material wrapper and different type, when comparing, then returns false")
+        void returnsFalse_whenComparedWithDifferentType() {
+            CustomItemWrapper wrapper = materialWrapper(Material.STONE);
+            assertNotEquals(wrapper, "not a wrapper");
+        }
+
+        @Test
+        @DisplayName("Given one material and one custom wrapper, when comparing as Object, then returns false")
+        void returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
+            CustomItemWrapper a = materialWrapper(Material.STONE);
+            CustomItemWrapper b = customItemWrapper("nexo:stone");
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different material wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenMaterialsDiffer() {
+            CustomItemWrapper a = materialWrapper(Material.STONE);
+            CustomItemWrapper b = materialWrapper(Material.DIRT);
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("Given two different custom item wrappers, when comparing as Object, then returns false")
+        void returnsFalse_whenCustomItemsDiffer() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:sapphire");
+            assertNotEquals(a, b);
+        }
+    }
+
+    // ── hashCode ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("hashCode")
+    class HashCode {
+
+        @Test
+        @DisplayName("Given two equal material wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualMaterialWrappers() {
+            CustomItemWrapper a = materialWrapper(Material.STONE);
+            CustomItemWrapper b = materialWrapper(Material.STONE);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two equal custom item wrappers, then hashCodes are equal")
+        void hashCodesEqual_forEqualCustomItemWrappers() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:ruby");
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given material wrapper, then hashCode is consistent across calls")
+        void hashCode_isConsistent() {
+            CustomItemWrapper wrapper = materialWrapper(Material.DIAMOND);
+            int first = wrapper.hashCode();
+            int second = wrapper.hashCode();
+            assertEquals(first, second);
+        }
+    }
+
+    // ── itemName ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("itemName")
+    class ItemName {
+
+        @Test
+        @DisplayName("Given custom item wrapper with no hooks registered, when getting itemName, then returns Missing Item")
+        void returnsMissingItem_whenNoHooksRegistered() throws Exception {
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertEquals("Missing Item", wrapper.itemName());
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/util/item/CustomItemWrapperTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/item/CustomItemWrapperTest.java
@@ -1,7 +1,14 @@
 package com.diamonddagger590.mccore.util.item;
 
+import com.diamonddagger590.mccore.CorePlugin;
+import com.diamonddagger590.mccore.external.common.CustomItemHook;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.registry.plugin.PluginHook;
 import com.diamonddagger590.mccore.testing.RegistryResetExtension;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +16,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,51 +51,85 @@ class CustomItemWrapperTest {
         return wrapper;
     }
 
-    // ── Material constructor ────────────────────────────────────────────────
+    static class TestCustomItemPluginHook extends PluginHook<CorePlugin> implements CustomItemHook {
+
+        TestCustomItemPluginHook() {
+            super(null);
+        }
+
+        @Override
+        public boolean isItem(@NotNull String itemName) {
+            return "nexo:ruby_sword".equals(itemName);
+        }
+
+        @Override
+        public boolean isItem(@NotNull ItemStack itemStack) {
+            return false;
+        }
+
+        @Override
+        public boolean isItemOfType(@NotNull ItemStack itemStack, @NotNull String itemName) {
+            return false;
+        }
+
+        @NotNull
+        @Override
+        public Optional<ItemStack> item(@NotNull String itemName) {
+            return Optional.empty();
+        }
+
+        @NotNull
+        @Override
+        public Optional<Set<String>> itemModels(@NotNull ItemStack itemStack) {
+            return Optional.empty();
+        }
+
+        @NotNull
+        @Override
+        public String itemName(@NotNull CustomItemWrapper customItemWrapper) {
+            return "Ruby Sword";
+        }
+    }
 
     @Nested
     @DisplayName("Material constructor")
     class MaterialConstructor {
 
         @Test
-        @DisplayName("Given a material, when constructing, then material() returns that material")
-        void material_returnsProvidedMaterial() {
+        @DisplayName("Given a material, when getting material, then returns that material")
+        void material_returnsProvidedMaterial_whenConstructedWithMaterial() {
             CustomItemWrapper wrapper = materialWrapper(Material.DIAMOND);
             assertTrue(wrapper.material().isPresent());
             assertEquals(Material.DIAMOND, wrapper.material().get());
         }
 
         @Test
-        @DisplayName("Given a material, when constructing, then customItem() returns empty")
+        @DisplayName("Given a material, when getting customItem, then returns empty")
         void customItem_returnsEmpty_whenConstructedWithMaterial() {
             CustomItemWrapper wrapper = materialWrapper(Material.STONE);
             assertFalse(wrapper.customItem().isPresent());
         }
     }
 
-    // ── Custom item wrapper (reflective construction) ───────────────────────
-
     @Nested
     @DisplayName("Custom item accessors")
     class CustomItemAccessors {
 
         @Test
-        @DisplayName("Given a custom item wrapper, then customItem() returns the custom item id")
-        void customItem_returnsId() throws Exception {
+        @DisplayName("Given a custom item wrapper, when getting customItem, then returns the custom item id")
+        void customItem_returnsId_whenConstructedWithCustomItem() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
             assertTrue(wrapper.customItem().isPresent());
             assertEquals("nexo:ruby_sword", wrapper.customItem().get());
         }
 
         @Test
-        @DisplayName("Given a custom item wrapper, then material() returns empty")
-        void material_returnsEmpty_whenCustomItem() throws Exception {
+        @DisplayName("Given a custom item wrapper, when getting material, then returns empty")
+        void material_returnsEmpty_whenConstructedWithCustomItem() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
             assertFalse(wrapper.material().isPresent());
         }
     }
-
-    // ── equals(Material) ────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(Material)")
@@ -94,27 +137,25 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given matching material, when comparing, then returns true")
-        void returnsTrue_whenMaterialMatches() {
+        void equals_returnsTrue_whenMaterialMatches() {
             CustomItemWrapper wrapper = materialWrapper(Material.IRON_INGOT);
             assertTrue(wrapper.equals(Material.IRON_INGOT));
         }
 
         @Test
         @DisplayName("Given different material, when comparing, then returns false")
-        void returnsFalse_whenMaterialDiffers() {
+        void equals_returnsFalse_whenMaterialDiffers() {
             CustomItemWrapper wrapper = materialWrapper(Material.IRON_INGOT);
             assertFalse(wrapper.equals(Material.GOLD_INGOT));
         }
 
         @Test
         @DisplayName("Given custom item wrapper, when comparing with any material, then returns false")
-        void returnsFalse_whenWrapperIsCustomItem() throws Exception {
+        void equals_returnsFalse_whenWrapperIsCustomItem() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby");
             assertFalse(wrapper.equals(Material.DIAMOND));
         }
     }
-
-    // ── equals(String) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(String)")
@@ -122,27 +163,25 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given matching custom item id, when comparing, then returns true")
-        void returnsTrue_whenCustomItemMatches() throws Exception {
+        void equals_returnsTrue_whenCustomItemMatches() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
             assertTrue(wrapper.equals("nexo:ruby_sword"));
         }
 
         @Test
         @DisplayName("Given different custom item id, when comparing, then returns false")
-        void returnsFalse_whenCustomItemDiffers() throws Exception {
+        void equals_returnsFalse_whenCustomItemDiffers() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
             assertFalse(wrapper.equals("nexo:diamond_sword"));
         }
 
         @Test
         @DisplayName("Given material wrapper, when comparing with any string, then returns false")
-        void returnsFalse_whenWrapperIsMaterial() {
+        void equals_returnsFalse_whenWrapperIsMaterial() {
             CustomItemWrapper wrapper = materialWrapper(Material.STONE);
             assertFalse(wrapper.equals("stone"));
         }
     }
-
-    // ── equals(CustomItemWrapper) ───────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(CustomItemWrapper)")
@@ -150,7 +189,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two material wrappers with same material, when comparing, then returns true")
-        void returnsTrue_whenBothMaterialsMatch() {
+        void equals_returnsTrue_whenBothMaterialsMatch() {
             CustomItemWrapper a = materialWrapper(Material.DIAMOND);
             CustomItemWrapper b = materialWrapper(Material.DIAMOND);
             assertTrue(a.equals(b));
@@ -158,7 +197,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two material wrappers with different materials, when comparing, then returns false")
-        void returnsFalse_whenMaterialsDiffer() {
+        void equals_returnsFalse_whenMaterialsDiffer() {
             CustomItemWrapper a = materialWrapper(Material.DIAMOND);
             CustomItemWrapper b = materialWrapper(Material.EMERALD);
             assertFalse(a.equals(b));
@@ -166,7 +205,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two custom item wrappers with same id, when comparing, then returns true")
-        void returnsTrue_whenBothCustomItemsMatch() throws Exception {
+        void equals_returnsTrue_whenBothCustomItemsMatch() throws Exception {
             CustomItemWrapper a = customItemWrapper("nexo:ruby");
             CustomItemWrapper b = customItemWrapper("nexo:ruby");
             assertTrue(a.equals(b));
@@ -174,7 +213,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two custom item wrappers with different ids, when comparing, then returns false")
-        void returnsFalse_whenCustomItemsDiffer() throws Exception {
+        void equals_returnsFalse_whenCustomItemsDiffer() throws Exception {
             CustomItemWrapper a = customItemWrapper("nexo:ruby");
             CustomItemWrapper b = customItemWrapper("nexo:sapphire");
             assertFalse(a.equals(b));
@@ -182,14 +221,12 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given material wrapper and custom item wrapper, when comparing, then returns false")
-        void returnsFalse_whenTypesAreMixed() throws Exception {
+        void equals_returnsFalse_whenTypesAreMixed() throws Exception {
             CustomItemWrapper materialBased = materialWrapper(Material.STONE);
             CustomItemWrapper customBased = customItemWrapper("nexo:stone");
             assertFalse(materialBased.equals(customBased));
         }
     }
-
-    // ── equals(Object) ──────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("equals(Object)")
@@ -197,14 +234,21 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given same instance, when comparing, then returns true")
-        void returnsTrue_forSameInstance() {
+        void equals_returnsTrue_whenSameInstance() {
             CustomItemWrapper wrapper = materialWrapper(Material.STONE);
             assertEquals(wrapper, wrapper);
         }
 
         @Test
+        @DisplayName("Given null, when comparing, then returns false")
+        void equals_returnsFalse_whenComparedWithNull() {
+            CustomItemWrapper wrapper = materialWrapper(Material.STONE);
+            assertNotEquals(null, wrapper);
+        }
+
+        @Test
         @DisplayName("Given two material wrappers with same material, when comparing as Object, then returns true")
-        void returnsTrue_whenMaterialWrappersMatch() {
+        void equals_returnsTrue_whenMaterialWrappersMatch() {
             CustomItemWrapper a = materialWrapper(Material.STONE);
             CustomItemWrapper b = materialWrapper(Material.STONE);
             assertEquals(a, b);
@@ -212,7 +256,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two custom item wrappers with same id, when comparing as Object, then returns true")
-        void returnsTrue_whenCustomItemWrappersMatch() throws Exception {
+        void equals_returnsTrue_whenCustomItemWrappersMatch() throws Exception {
             CustomItemWrapper a = customItemWrapper("nexo:ruby");
             CustomItemWrapper b = customItemWrapper("nexo:ruby");
             assertEquals(a, b);
@@ -220,14 +264,14 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given material wrapper and different type, when comparing, then returns false")
-        void returnsFalse_whenComparedWithDifferentType() {
+        void equals_returnsFalse_whenComparedWithDifferentType() {
             CustomItemWrapper wrapper = materialWrapper(Material.STONE);
             assertNotEquals(wrapper, "not a wrapper");
         }
 
         @Test
         @DisplayName("Given one material and one custom wrapper, when comparing as Object, then returns false")
-        void returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
+        void equals_returnsFalse_whenOneIsMaterialAndOtherIsCustom() throws Exception {
             CustomItemWrapper a = materialWrapper(Material.STONE);
             CustomItemWrapper b = customItemWrapper("nexo:stone");
             assertNotEquals(a, b);
@@ -235,7 +279,7 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two different material wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenMaterialsDiffer() {
+        void equals_returnsFalse_whenMaterialsDiffer() {
             CustomItemWrapper a = materialWrapper(Material.STONE);
             CustomItemWrapper b = materialWrapper(Material.DIRT);
             assertNotEquals(a, b);
@@ -243,46 +287,58 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given two different custom item wrappers, when comparing as Object, then returns false")
-        void returnsFalse_whenCustomItemsDiffer() throws Exception {
+        void equals_returnsFalse_whenCustomItemsDiffer() throws Exception {
             CustomItemWrapper a = customItemWrapper("nexo:ruby");
             CustomItemWrapper b = customItemWrapper("nexo:sapphire");
             assertNotEquals(a, b);
         }
     }
 
-    // ── hashCode ────────────────────────────────────────────────────────────
-
     @Nested
     @DisplayName("hashCode")
     class HashCode {
 
         @Test
-        @DisplayName("Given two equal material wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualMaterialWrappers() {
+        @DisplayName("Given two equal material wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenMaterialWrappersAreEqual() {
             CustomItemWrapper a = materialWrapper(Material.STONE);
             CustomItemWrapper b = materialWrapper(Material.STONE);
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given two equal custom item wrappers, then hashCodes are equal")
-        void hashCodesEqual_forEqualCustomItemWrappers() throws Exception {
+        @DisplayName("Given two equal custom item wrappers, when getting hashCode, then values are equal")
+        void hashCode_returnsEqualValues_whenCustomItemWrappersAreEqual() throws Exception {
             CustomItemWrapper a = customItemWrapper("nexo:ruby");
             CustomItemWrapper b = customItemWrapper("nexo:ruby");
             assertEquals(a.hashCode(), b.hashCode());
         }
 
         @Test
-        @DisplayName("Given material wrapper, then hashCode is consistent across calls")
-        void hashCode_isConsistent() {
+        @DisplayName("Given material wrapper, when getting hashCode multiple times, then value is consistent")
+        void hashCode_returnsSameValue_whenCalledMultipleTimes() {
             CustomItemWrapper wrapper = materialWrapper(Material.DIAMOND);
             int first = wrapper.hashCode();
             int second = wrapper.hashCode();
             assertEquals(first, second);
         }
-    }
 
-    // ── itemName ────────────────────────────────────────────────────────────
+        @Test
+        @DisplayName("Given two unequal material wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenMaterialWrappersDiffer() {
+            CustomItemWrapper a = materialWrapper(Material.STONE);
+            CustomItemWrapper b = materialWrapper(Material.DIAMOND);
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("Given two unequal custom item wrappers, when getting hashCode, then values differ")
+        void hashCode_returnsDifferentValues_whenCustomItemWrappersDiffer() throws Exception {
+            CustomItemWrapper a = customItemWrapper("nexo:ruby");
+            CustomItemWrapper b = customItemWrapper("nexo:sapphire");
+            assertNotEquals(a.hashCode(), b.hashCode());
+        }
+    }
 
     @Nested
     @DisplayName("itemName")
@@ -290,9 +346,17 @@ class CustomItemWrapperTest {
 
         @Test
         @DisplayName("Given custom item wrapper with no hooks registered, when getting itemName, then returns Missing Item")
-        void returnsMissingItem_whenNoHooksRegistered() throws Exception {
+        void itemName_returnsMissingItem_whenNoHooksRegistered() throws Exception {
             CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
             assertEquals("Missing Item", wrapper.itemName());
+        }
+
+        @Test
+        @DisplayName("Given custom item wrapper with a hook registered, when getting itemName, then returns hook-provided name")
+        void itemName_returnsHookProvidedName_whenHookIsRegistered() throws Exception {
+            RegistryAccess.registryAccess().registry(RegistryKey.PLUGIN_HOOK).register(new TestCustomItemPluginHook());
+            CustomItemWrapper wrapper = customItemWrapper("nexo:ruby_sword");
+            assertEquals("Ruby Sword", wrapper.itemName());
         }
     }
 }


### PR DESCRIPTION
## Summary

- **CustomItemWrapperTest** (30 tests): Tests Material constructor accessors, reflective custom-item construction accessors, `equals(Material)` for match/mismatch/custom-item paths, `equals(String)` for match/mismatch/material paths, `equals(CustomItemWrapper)` for same-material/different-material/same-custom/different-custom/cross-type, `equals(Object)` for identity/null/match/mismatch/different-type/cross-type, `hashCode` consistency, equality contract, and inequality contract, `itemName()` fallback to "Missing Item" when no hooks are registered, and `itemName()` delegation to a registered `CustomItemHook` (0% → ~40% line coverage)
- **CustomEntityWrapperTest** (30 tests): Tests EntityType constructor accessors, reflective custom-entity construction accessors, `equals(EntityType)` for match/mismatch/custom-entity paths, `equals(String)` for match/mismatch/entity-type paths, `equals(CustomEntityWrapper)` for same-type/different-type/same-custom/different-custom/cross-type, `equals(Object)` for identity/null/match/mismatch/different-type/cross-type, `hashCode` consistency, equality contract, and inequality contract, `entityName()` fallback to "Unknown" when no hooks are registered, and `entityName()` delegation to a registered `CustomEntityHook` (0% → ~40% line coverage)
- **CustomBlockWrapperTest** (31 tests): Tests Material constructor accessors, reflective custom-block construction accessors, `equals(Material)` for match/mismatch/custom-block paths, `equals(String)` for match/mismatch/material paths, `equals(CustomItemWrapper)` cross-type comparison for same-material/different-material/same-custom/cross-type, `equals(Object)` for identity/null/match/mismatch/different-type/cross-type, `hashCode` consistency, equality contract, and inequality contract, `blockName()` fallback to "Missing Block" when no hooks are registered, `blockName()` delegation to a registered `CustomBlockHook`, and `toString()` for both material and custom-block variants (0% → ~30% line coverage)

### Classes covered (avoiding PR #27 through PR #39 overlap)
All three wrapper classes were previously at 0% coverage. Remaining uncovered lines are constructors and methods that require Paper server runtime (`translationKey()`, `ItemBuilder.from()`, Paper registry lookups) — these would need MockBukkit or an integration test environment.

### Test approach
Uses reflection to construct custom-item/entity/block wrapper instances (bypassing the String constructor which calls `io.papermc.paper.registry.RegistryAccess`), and `RegistryResetExtension` to initialize the McCore registry with empty hook lists for testing fallback paths. Hook-registered name resolution tests create inner `PluginHook` implementations that implement the respective hook interface (`CustomItemHook`, `CustomEntityHook`, `CustomBlockHook`), register them with `PluginHookRegistry`, and verify that the wrapper's name method delegates to the hook.

## Test plan
- [x] All 91 new tests pass locally via `./gradlew test`
- [x] All 750+ existing tests continue to pass (no regressions)
- [x] JaCoCo coverage report confirms line coverage increases
- [x] All CodeRabbit review feedback addressed (null edge cases, method naming, hashCode inequality, hook name tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SaCExwqbmpShntuFdLHkd