### PR TITLE
[Tests] Add unit tests for ModificationType, GuiRefreshEvent, PlayerLoadEvent, PlayerUnloadEvent

### DIFF
--- a/src/test/java/com/diamonddagger590/mccore/event/gui/GuiRefreshEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/gui/GuiRefreshEventTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -103,6 +104,6 @@ class GuiRefreshEventTest {
     void getEventName_returnsClassName() {
         Gui<?> gui = createStubGui();
         GuiRefreshEvent event = new GuiRefreshEvent(gui);
-        assertNotNull(event.getEventName());
+        assertEquals("GuiRefreshEvent", event.getEventName());
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/event/gui/GuiRefreshEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/gui/GuiRefreshEventTest.java
@@ -1,0 +1,108 @@
+package com.diamonddagger590.mccore.event.gui;
+
+import com.diamonddagger590.mccore.gui.Gui;
+import com.diamonddagger590.mccore.gui.slot.Slot;
+import com.diamonddagger590.mccore.player.CorePlayer;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GuiRefreshEventTest {
+
+    private static Gui<?> createStubGui() {
+        return new Gui<>() {
+            private final UUID uuid = UUID.randomUUID();
+
+            @Override
+            @NotNull
+            public UUID getUUID() {
+                return uuid;
+            }
+
+            @Override
+            @NotNull
+            public Slot<CorePlayer> getSlot(int index) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            @NotNull
+            public Inventory getInventory() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void handleClickEvent(@NotNull InventoryClickEvent inventoryClickEvent) {
+            }
+
+            @Override
+            public void paintInventory() {
+            }
+
+            @Override
+            public void registerListeners() {
+            }
+
+            @Override
+            public void unregisterListeners() {
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Given a Gui, when constructing GuiRefreshEvent, then getGui returns the same instance")
+    void getGui_returnsSameInstance_whenConstructedWithGui() {
+        Gui<?> gui = createStubGui();
+        GuiRefreshEvent event = new GuiRefreshEvent(gui);
+        assertSame(gui, event.getGui());
+    }
+
+    @Test
+    @DisplayName("Given a GuiRefreshEvent, when calling getHandlers, then returns non-null HandlerList")
+    void getHandlers_returnsNonNull() {
+        Gui<?> gui = createStubGui();
+        GuiRefreshEvent event = new GuiRefreshEvent(gui);
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given GuiRefreshEvent class, when calling getHandlerList, then returns non-null HandlerList")
+    void getHandlerList_returnsNonNull() {
+        assertNotNull(GuiRefreshEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given a GuiRefreshEvent, when calling getHandlers and getHandlerList, then they return the same instance")
+    void getHandlers_andGetHandlerList_returnSameInstance() {
+        Gui<?> gui = createStubGui();
+        GuiRefreshEvent event = new GuiRefreshEvent(gui);
+        assertSame(event.getHandlers(), GuiRefreshEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given two GuiRefreshEvents with different guis, when calling getGui, then each returns its own gui")
+    void getGui_returnsDistinctInstances_forDifferentEvents() {
+        Gui<?> gui1 = createStubGui();
+        Gui<?> gui2 = createStubGui();
+        GuiRefreshEvent event1 = new GuiRefreshEvent(gui1);
+        GuiRefreshEvent event2 = new GuiRefreshEvent(gui2);
+        assertSame(gui1, event1.getGui());
+        assertSame(gui2, event2.getGui());
+    }
+
+    @Test
+    @DisplayName("Given a GuiRefreshEvent, when calling getEventName, then returns the class simple name")
+    void getEventName_returnsClassName() {
+        Gui<?> gui = createStubGui();
+        GuiRefreshEvent event = new GuiRefreshEvent(gui);
+        assertNotNull(event.getEventName());
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/event/player/PlayerLoadEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/player/PlayerLoadEventTest.java
@@ -1,0 +1,95 @@
+package com.diamonddagger590.mccore.event.player;
+
+import com.diamonddagger590.mccore.player.CorePlayer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PlayerLoadEventTest {
+
+    private static CorePlayer createStubPlayer(UUID uuid) {
+        return new CorePlayer(uuid, null) {
+            @Override
+            public boolean useMutex() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Given a CorePlayer, when constructing PlayerLoadEvent, then getCorePlayer returns the same player")
+    void getCorePlayer_returnsSameInstance_whenConstructed() {
+        UUID uuid = UUID.randomUUID();
+        CorePlayer player = createStubPlayer(uuid);
+
+        PlayerLoadEvent event = new PlayerLoadEvent(player);
+
+        assertSame(player, event.getCorePlayer());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerLoadEvent, when calling getCorePlayer, then the UUID matches")
+    void getCorePlayer_hasCorrectUUID() {
+        UUID uuid = UUID.randomUUID();
+        CorePlayer player = createStubPlayer(uuid);
+
+        PlayerLoadEvent event = new PlayerLoadEvent(player);
+
+        assertEquals(uuid, event.getCorePlayer().getUUID());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerLoadEvent, when calling getHandlers, then returns non-null HandlerList")
+    void getHandlers_returnsNonNull() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerLoadEvent event = new PlayerLoadEvent(player);
+
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given the PlayerLoadEvent class, when calling getHandlerList, then returns non-null HandlerList")
+    void getHandlerList_returnsNonNull() {
+        assertNotNull(PlayerLoadEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerLoadEvent, when calling getHandlers and getHandlerList, then they return the same instance")
+    void getHandlers_andGetHandlerList_returnSameInstance() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerLoadEvent event = new PlayerLoadEvent(player);
+
+        assertSame(event.getHandlers(), PlayerLoadEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given two PlayerLoadEvents with different players, when comparing, then each has its own player")
+    void events_haveDifferentPlayers_whenCreatedWithDifferentPlayers() {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        CorePlayer player1 = createStubPlayer(uuid1);
+        CorePlayer player2 = createStubPlayer(uuid2);
+
+        PlayerLoadEvent event1 = new PlayerLoadEvent(player1);
+        PlayerLoadEvent event2 = new PlayerLoadEvent(player2);
+
+        assertSame(player1, event1.getCorePlayer());
+        assertSame(player2, event2.getCorePlayer());
+        assertEquals(uuid1, event1.getCorePlayer().getUUID());
+        assertEquals(uuid2, event2.getCorePlayer().getUUID());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerLoadEvent, when calling getEventName, then returns a non-null string")
+    void getEventName_returnsNonNull() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerLoadEvent event = new PlayerLoadEvent(player);
+
+        assertNotNull(event.getEventName());
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/event/player/PlayerLoadEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/player/PlayerLoadEventTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class PlayerLoadEventTest {
@@ -91,5 +93,12 @@ class PlayerLoadEventTest {
         PlayerLoadEvent event = new PlayerLoadEvent(player);
 
         assertNotNull(event.getEventName());
+    }
+
+    @Test
+    @DisplayName("Given null player, when constructing PlayerLoadEvent, then does not throw at construction")
+    void constructor_doesNotThrow_whenPlayerIsNull() {
+        PlayerLoadEvent event = assertDoesNotThrow(() -> new PlayerLoadEvent(null));
+        assertNull(event.getCorePlayer());
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/event/player/PlayerUnloadEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/player/PlayerUnloadEventTest.java
@@ -1,0 +1,95 @@
+package com.diamonddagger590.mccore.event.player;
+
+import com.diamonddagger590.mccore.player.CorePlayer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PlayerUnloadEventTest {
+
+    private static CorePlayer createStubPlayer(UUID uuid) {
+        return new CorePlayer(uuid, null) {
+            @Override
+            public boolean useMutex() {
+                return false;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Given a CorePlayer, when constructing PlayerUnloadEvent, then getCorePlayer returns the same player")
+    void getCorePlayer_returnsSameInstance_whenConstructed() {
+        UUID uuid = UUID.randomUUID();
+        CorePlayer player = createStubPlayer(uuid);
+
+        PlayerUnloadEvent event = new PlayerUnloadEvent(player);
+
+        assertSame(player, event.getCorePlayer());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerUnloadEvent, when calling getCorePlayer, then the UUID matches")
+    void getCorePlayer_hasCorrectUUID() {
+        UUID uuid = UUID.randomUUID();
+        CorePlayer player = createStubPlayer(uuid);
+
+        PlayerUnloadEvent event = new PlayerUnloadEvent(player);
+
+        assertEquals(uuid, event.getCorePlayer().getUUID());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerUnloadEvent, when calling getHandlers, then returns non-null HandlerList")
+    void getHandlers_returnsNonNull() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerUnloadEvent event = new PlayerUnloadEvent(player);
+
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given the PlayerUnloadEvent class, when calling getHandlerList, then returns non-null HandlerList")
+    void getHandlerList_returnsNonNull() {
+        assertNotNull(PlayerUnloadEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerUnloadEvent, when calling getHandlers and getHandlerList, then they return the same instance")
+    void getHandlers_andGetHandlerList_returnSameInstance() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerUnloadEvent event = new PlayerUnloadEvent(player);
+
+        assertSame(event.getHandlers(), PlayerUnloadEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Given two PlayerUnloadEvents with different players, when comparing, then each has its own player")
+    void events_haveDifferentPlayers_whenCreatedWithDifferentPlayers() {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        CorePlayer player1 = createStubPlayer(uuid1);
+        CorePlayer player2 = createStubPlayer(uuid2);
+
+        PlayerUnloadEvent event1 = new PlayerUnloadEvent(player1);
+        PlayerUnloadEvent event2 = new PlayerUnloadEvent(player2);
+
+        assertSame(player1, event1.getCorePlayer());
+        assertSame(player2, event2.getCorePlayer());
+        assertEquals(uuid1, event1.getCorePlayer().getUUID());
+        assertEquals(uuid2, event2.getCorePlayer().getUUID());
+    }
+
+    @Test
+    @DisplayName("Given a PlayerUnloadEvent, when calling getEventName, then returns a non-null string")
+    void getEventName_returnsNonNull() {
+        CorePlayer player = createStubPlayer(UUID.randomUUID());
+        PlayerUnloadEvent event = new PlayerUnloadEvent(player);
+
+        assertNotNull(event.getEventName());
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/event/player/PlayerUnloadEventTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/player/PlayerUnloadEventTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class PlayerUnloadEventTest {
@@ -91,5 +93,12 @@ class PlayerUnloadEventTest {
         PlayerUnloadEvent event = new PlayerUnloadEvent(player);
 
         assertNotNull(event.getEventName());
+    }
+
+    @Test
+    @DisplayName("Given null player, when constructing PlayerUnloadEvent, then does not throw at construction")
+    void constructor_doesNotThrow_whenPlayerIsNull() {
+        PlayerUnloadEvent event = assertDoesNotThrow(() -> new PlayerUnloadEvent(null));
+        assertNull(event.getCorePlayer());
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/event/statistic/ModificationTypeTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/statistic/ModificationTypeTest.java
@@ -1,0 +1,90 @@
+package com.diamonddagger590.mccore.event.statistic;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ModificationTypeTest {
+
+    @Test
+    @DisplayName("Given the ModificationType enum, when calling values(), then all six types are present")
+    void values_returnsAllSixTypes() {
+        ModificationType[] values = ModificationType.values();
+        assertEquals(6, values.length);
+    }
+
+    @Test
+    @DisplayName("Given SET, when calling valueOf, then returns SET")
+    void valueOf_returnsSET_whenGivenSET() {
+        assertEquals(ModificationType.SET, ModificationType.valueOf("SET"));
+    }
+
+    @Test
+    @DisplayName("Given INCREMENT, when calling valueOf, then returns INCREMENT")
+    void valueOf_returnsINCREMENT_whenGivenINCREMENT() {
+        assertEquals(ModificationType.INCREMENT, ModificationType.valueOf("INCREMENT"));
+    }
+
+    @Test
+    @DisplayName("Given ADD_TO_SET, when calling valueOf, then returns ADD_TO_SET")
+    void valueOf_returnsADD_TO_SET_whenGivenADD_TO_SET() {
+        assertEquals(ModificationType.ADD_TO_SET, ModificationType.valueOf("ADD_TO_SET"));
+    }
+
+    @Test
+    @DisplayName("Given REMOVE_FROM_SET, when calling valueOf, then returns REMOVE_FROM_SET")
+    void valueOf_returnsREMOVE_FROM_SET_whenGivenREMOVE_FROM_SET() {
+        assertEquals(ModificationType.REMOVE_FROM_SET, ModificationType.valueOf("REMOVE_FROM_SET"));
+    }
+
+    @Test
+    @DisplayName("Given SET_MAX, when calling valueOf, then returns SET_MAX")
+    void valueOf_returnsSET_MAX_whenGivenSET_MAX() {
+        assertEquals(ModificationType.SET_MAX, ModificationType.valueOf("SET_MAX"));
+    }
+
+    @Test
+    @DisplayName("Given SET_IF_ABSENT, when calling valueOf, then returns SET_IF_ABSENT")
+    void valueOf_returnsSET_IF_ABSENT_whenGivenSET_IF_ABSENT() {
+        assertEquals(ModificationType.SET_IF_ABSENT, ModificationType.valueOf("SET_IF_ABSENT"));
+    }
+
+    @Test
+    @DisplayName("Given an invalid name, when calling valueOf, then throws IllegalArgumentException")
+    void valueOf_throwsException_whenGivenInvalidName() {
+        assertThrows(IllegalArgumentException.class, () -> ModificationType.valueOf("INVALID"));
+    }
+
+    @Test
+    @DisplayName("Given each ModificationType, when calling name(), then returns the expected string")
+    void name_returnsExpectedString_forEachType() {
+        assertEquals("SET", ModificationType.SET.name());
+        assertEquals("INCREMENT", ModificationType.INCREMENT.name());
+        assertEquals("ADD_TO_SET", ModificationType.ADD_TO_SET.name());
+        assertEquals("REMOVE_FROM_SET", ModificationType.REMOVE_FROM_SET.name());
+        assertEquals("SET_MAX", ModificationType.SET_MAX.name());
+        assertEquals("SET_IF_ABSENT", ModificationType.SET_IF_ABSENT.name());
+    }
+
+    @Test
+    @DisplayName("Given each ModificationType, when calling ordinal(), then ordinals are sequential from zero")
+    void ordinal_isSequentialFromZero() {
+        assertEquals(0, ModificationType.SET.ordinal());
+        assertEquals(1, ModificationType.INCREMENT.ordinal());
+        assertEquals(2, ModificationType.ADD_TO_SET.ordinal());
+        assertEquals(3, ModificationType.REMOVE_FROM_SET.ordinal());
+        assertEquals(4, ModificationType.SET_MAX.ordinal());
+        assertEquals(5, ModificationType.SET_IF_ABSENT.ordinal());
+    }
+
+    @Test
+    @DisplayName("Given each ModificationType, when referenced, then is not null")
+    void allValues_areNotNull() {
+        for (ModificationType type : ModificationType.values()) {
+            assertNotNull(type);
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/event/statistic/ModificationTypeTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/statistic/ModificationTypeTest.java
@@ -59,6 +59,12 @@ class ModificationTypeTest {
     }
 
     @Test
+    @DisplayName("Given null, when calling valueOf, then throws NullPointerException")
+    void valueOf_throwsNullPointerException_whenGivenNull() {
+        assertThrows(NullPointerException.class, () -> ModificationType.valueOf(null));
+    }
+
+    @Test
     @DisplayName("Given each ModificationType, when calling name(), then returns the expected string")
     void name_returnsExpectedString_forEachType() {
         assertEquals("SET", ModificationType.SET.name());


### PR DESCRIPTION
## Summary

- **ModificationType** (12 tests): Covers `values()` count, `valueOf()` for all six enum constants, `valueOf()` with invalid name, `valueOf()` with null input, `name()` for each type, `ordinal()` ordering, and non-null check for all values
- **GuiRefreshEvent** (6 tests): Covers constructor storing gui reference, `getGui()` identity, `getHandlers()`/`getHandlerList()` non-null and identity, distinct gui instances across events, and `getEventName()` class name assertion
- **PlayerLoadEvent** (8 tests): Covers constructor storing player reference, UUID correctness, `getHandlers()`/`getHandlerList()` non-null and identity, distinct players across events, `getEventName()`, and null constructor input edge case
- **PlayerUnloadEvent** (8 tests): Covers constructor storing player reference, UUID correctness, `getHandlers()`/`getHandlerList()` non-null and identity, distinct players across events, `getEventName()`, and null constructor input edge case

### Test counts
| Class | Tests |
|-------|-------|
| ModificationType | 12 |
| GuiRefreshEvent | 6 |
| PlayerLoadEvent | 8 |
| PlayerUnloadEvent | 8 |
| **Total new** | **34** |

Note: `PlayerSettingChangeEventTest` was removed from this PR as it was already merged to develop via another PR.

### Review feedback addressed
- Strengthened `GuiRefreshEventTest.getEventName_returnsClassName` to use `assertEquals` instead of `assertNotNull`
- Added null-input edge case for `ModificationType.valueOf(null)`
- Added null constructor input tests for `PlayerLoadEvent` and `PlayerUnloadEvent`

## Test plan
- [x] All tests pass via `./gradlew test`
- [x] No duplicate coverage with existing open test PRs (#30–#42) or merged code on develop
- [x] Tests follow project naming conventions and existing test patterns
- [x] Review feedback from CodeRabbit addressed


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1VtDgREraH23rg24nMtUj