### PR TITLE
[Tests] Add unit tests for database events, ManagerKey, and improve Pair/Parser coverage

### DIFF
--- a/src/test/java/com/diamonddagger590/mccore/event/database/DatabaseTableEventsTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/database/DatabaseTableEventsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class DatabaseTableEventsTest {
@@ -109,5 +110,11 @@ class DatabaseTableEventsTest {
         assertNotNull(created);
         assertNotNull(preUpdate);
         assertNotNull(updated);
+        assertNotSame(preCreate, created);
+        assertNotSame(preCreate, preUpdate);
+        assertNotSame(preCreate, updated);
+        assertNotSame(created, preUpdate);
+        assertNotSame(created, updated);
+        assertNotSame(preUpdate, updated);
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/event/database/DatabaseTableEventsTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/event/database/DatabaseTableEventsTest.java
@@ -1,0 +1,113 @@
+package com.diamonddagger590.mccore.event.database;
+
+import org.bukkit.event.HandlerList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DatabaseTableEventsTest {
+
+    @Test
+    @DisplayName("Given PreTablesCreateEvent, when constructed, then getHandlers returns non-null HandlerList")
+    void preTablesCreateEvent_getHandlers_returnsNonNull() {
+        PreTablesCreateEvent event = new PreTablesCreateEvent();
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given PreTablesCreateEvent, when getHandlerList called, then returns same instance as getHandlers")
+    void preTablesCreateEvent_getHandlerList_returnsSameInstanceAsGetHandlers() {
+        PreTablesCreateEvent event = new PreTablesCreateEvent();
+        assertSame(PreTablesCreateEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given two PreTablesCreateEvents, when getHandlers called, then they share the same HandlerList")
+    void preTablesCreateEvent_handlerList_isSharedAcrossInstances() {
+        PreTablesCreateEvent event1 = new PreTablesCreateEvent();
+        PreTablesCreateEvent event2 = new PreTablesCreateEvent();
+        assertSame(event1.getHandlers(), event2.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given TablesCreatedEvent, when constructed, then getHandlers returns non-null HandlerList")
+    void tablesCreatedEvent_getHandlers_returnsNonNull() {
+        TablesCreatedEvent event = new TablesCreatedEvent();
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given TablesCreatedEvent, when getHandlerList called, then returns same instance as getHandlers")
+    void tablesCreatedEvent_getHandlerList_returnsSameInstanceAsGetHandlers() {
+        TablesCreatedEvent event = new TablesCreatedEvent();
+        assertSame(TablesCreatedEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given two TablesCreatedEvents, when getHandlers called, then they share the same HandlerList")
+    void tablesCreatedEvent_handlerList_isSharedAcrossInstances() {
+        TablesCreatedEvent event1 = new TablesCreatedEvent();
+        TablesCreatedEvent event2 = new TablesCreatedEvent();
+        assertSame(event1.getHandlers(), event2.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given PreTablesUpdateEvent, when constructed, then getHandlers returns non-null HandlerList")
+    void preTablesUpdateEvent_getHandlers_returnsNonNull() {
+        PreTablesUpdateEvent event = new PreTablesUpdateEvent();
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given PreTablesUpdateEvent, when getHandlerList called, then returns same instance as getHandlers")
+    void preTablesUpdateEvent_getHandlerList_returnsSameInstanceAsGetHandlers() {
+        PreTablesUpdateEvent event = new PreTablesUpdateEvent();
+        assertSame(PreTablesUpdateEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given two PreTablesUpdateEvents, when getHandlers called, then they share the same HandlerList")
+    void preTablesUpdateEvent_handlerList_isSharedAcrossInstances() {
+        PreTablesUpdateEvent event1 = new PreTablesUpdateEvent();
+        PreTablesUpdateEvent event2 = new PreTablesUpdateEvent();
+        assertSame(event1.getHandlers(), event2.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given TablesUpdatedEvent, when constructed, then getHandlers returns non-null HandlerList")
+    void tablesUpdatedEvent_getHandlers_returnsNonNull() {
+        TablesUpdatedEvent event = new TablesUpdatedEvent();
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given TablesUpdatedEvent, when getHandlerList called, then returns same instance as getHandlers")
+    void tablesUpdatedEvent_getHandlerList_returnsSameInstanceAsGetHandlers() {
+        TablesUpdatedEvent event = new TablesUpdatedEvent();
+        assertSame(TablesUpdatedEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given two TablesUpdatedEvents, when getHandlers called, then they share the same HandlerList")
+    void tablesUpdatedEvent_handlerList_isSharedAcrossInstances() {
+        TablesUpdatedEvent event1 = new TablesUpdatedEvent();
+        TablesUpdatedEvent event2 = new TablesUpdatedEvent();
+        assertSame(event1.getHandlers(), event2.getHandlers());
+    }
+
+    @Test
+    @DisplayName("Given all four event types, when getHandlerList called, then each type has its own distinct HandlerList")
+    void allDatabaseEvents_handlerLists_areDistinctPerType() {
+        HandlerList preCreate = PreTablesCreateEvent.getHandlerList();
+        HandlerList created = TablesCreatedEvent.getHandlerList();
+        HandlerList preUpdate = PreTablesUpdateEvent.getHandlerList();
+        HandlerList updated = TablesUpdatedEvent.getHandlerList();
+
+        assertNotNull(preCreate);
+        assertNotNull(created);
+        assertNotNull(preUpdate);
+        assertNotNull(updated);
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/pair/PairTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -141,5 +142,50 @@ class PairTest {
         pair2.setLeft("a");
         pair2.setRight(1);
         assertEquals(pair1, pair2);
+    }
+
+    @Test
+    @DisplayName("Given a pair, when equals called with non-Pair object, then returns false")
+    void equals_returnsFalse_whenCalledDirectlyWithNonPairObject() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
+        assertFalse(pair.equals("not a pair"));
+    }
+
+    @Test
+    @DisplayName("Given a pair, when equals called with null, then returns false")
+    void equals_returnsFalse_whenCalledDirectlyWithNull() {
+        ImmutablePair<String, Integer> pair = ImmutablePair.of("test", 1);
+        assertFalse(pair.equals(null));
+    }
+
+    @Test
+    @DisplayName("Given a pair with null left, when computing hashCode, then returns valid hash")
+    void hashCode_handlesNullLeft_whenLeftIsNull() {
+        MutablePair<String, Integer> pair = MutablePair.of(null, 42);
+        int hash = pair.hashCode();
+        assertEquals(42, hash);
+    }
+
+    @Test
+    @DisplayName("Given a pair with null right, when computing hashCode, then returns valid hash")
+    void hashCode_handlesNullRight_whenRightIsNull() {
+        MutablePair<String, Integer> pair = MutablePair.of("test", null);
+        int hash = pair.hashCode();
+        assertEquals("test".hashCode(), hash);
+    }
+
+    @Test
+    @DisplayName("Given a pair with both nulls, when computing hashCode, then returns zero")
+    void hashCode_returnsZero_whenBothSidesAreNull() {
+        MutablePair<String, Integer> pair = MutablePair.of(null, null);
+        assertEquals(0, pair.hashCode());
+    }
+
+    @Test
+    @DisplayName("Given two pairs with null values in same positions, when comparing, then they are equal")
+    void equals_returnsTrue_whenBothPairsHaveNullValues() {
+        MutablePair<String, Integer> pair1 = MutablePair.of(null, null);
+        MutablePair<String, Integer> pair2 = MutablePair.of(null, null);
+        assertTrue(pair1.equals(pair2));
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
@@ -415,4 +415,39 @@ class ParserTest {
     void getValue_appliesCorrectPrecedence_whenOperatorsAreMixed() {
         assertEquals(12.0, new Parser("2+3*4-6/2+1").getValue(), DELTA);
     }
+
+    @Test
+    @DisplayName("Given trailing extra token after valid expression, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenExtraTokenAfterExpression() {
+        assertThrows(ParseError.class, () -> new Parser("2+3)").getValue());
+    }
+
+    @Test
+    @DisplayName("Given unmatched closing parenthesis mid-expression, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenUnmatchedClosingParenMidExpression() {
+        assertThrows(ParseError.class, () -> new Parser(")2+3").getValue());
+    }
+
+    @Test
+    @DisplayName("Given function call missing closing bracket, when evaluating, then throws ParseError")
+    void getValue_throwsParseError_whenFunctionCallMissingClosingBracket() {
+        assertThrows(ParseError.class, () -> new Parser("sin(2+3").getValue());
+    }
+
+    @Test
+    @DisplayName("Given expression with getInputString, when called, then returns sanitized input")
+    void getInputString_returnsSanitizedInput_whenCalled() {
+        Parser parser = new Parser("2 + 3");
+        String input = parser.getInputString();
+        assertFalse(input.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Given expression with getTree called twice, when called, then returns cached tree")
+    void getTree_returnsCachedTree_whenCalledTwice() {
+        Parser parser = new Parser("2+3");
+        ExpressionNode tree1 = parser.getTree();
+        ExpressionNode tree2 = parser.getTree();
+        assertEquals(tree1.getValue(), tree2.getValue(), DELTA);
+    }
 }

--- a/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/parser/ParserTest.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -435,19 +436,18 @@ class ParserTest {
     }
 
     @Test
-    @DisplayName("Given expression with getInputString, when called, then returns sanitized input")
-    void getInputString_returnsSanitizedInput_whenCalled() {
+    @DisplayName("Given expression with spaces, when getInputString called, then returns input with spaces stripped")
+    void getInputString_returnsStrippedInput_whenExpressionContainsSpaces() {
         Parser parser = new Parser("2 + 3");
-        String input = parser.getInputString();
-        assertFalse(input.isEmpty());
+        assertEquals("2+3", parser.getInputString());
     }
 
     @Test
-    @DisplayName("Given expression with getTree called twice, when called, then returns cached tree")
-    void getTree_returnsCachedTree_whenCalledTwice() {
+    @DisplayName("Given a parsed expression, when getTree called twice, then returns the same cached instance")
+    void getTree_returnsSameCachedInstance_whenCalledTwice() {
         Parser parser = new Parser("2+3");
         ExpressionNode tree1 = parser.getTree();
         ExpressionNode tree2 = parser.getTree();
-        assertEquals(tree1.getValue(), tree2.getValue(), DELTA);
+        assertSame(tree1, tree2);
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerKeyTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerKeyTest.java
@@ -12,22 +12,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class ManagerKeyTest {
 
     @Test
-    @DisplayName("Given COMMAND key, when managerClass called, then returns CoreCommandManager class")
-    void command_managerClass_returnsCoreCommandManagerClass() {
+    @DisplayName("Given the COMMAND key constant, when managerClass called, then returns CoreCommandManager class")
+    void managerClass_returnsCoreCommandManagerClass_whenKeyIsCommand() {
         assertNotNull(ManagerKey.COMMAND);
         assertEquals(CoreCommandManager.class, ManagerKey.COMMAND.managerClass());
     }
 
     @Test
-    @DisplayName("Given RELOADABLE_CONTENT key, when managerClass called, then returns ReloadableContentManager class")
-    void reloadableContent_managerClass_returnsReloadableContentManagerClass() {
+    @DisplayName("Given the RELOADABLE_CONTENT key constant, when managerClass called, then returns ReloadableContentManager class")
+    void managerClass_returnsReloadableContentManagerClass_whenKeyIsReloadableContent() {
         assertNotNull(ManagerKey.RELOADABLE_CONTENT);
         assertEquals(ReloadableContentManager.class, ManagerKey.RELOADABLE_CONTENT.managerClass());
     }
 
     @Test
-    @DisplayName("Given CHAT_RESPONSE key, when managerClass called, then returns ChatResponseManager class")
-    void chatResponse_managerClass_returnsChatResponseManagerClass() {
+    @DisplayName("Given the CHAT_RESPONSE key constant, when managerClass called, then returns ChatResponseManager class")
+    void managerClass_returnsChatResponseManagerClass_whenKeyIsChatResponse() {
         assertNotNull(ManagerKey.CHAT_RESPONSE);
         assertEquals(ChatResponseManager.class, ManagerKey.CHAT_RESPONSE.managerClass());
     }

--- a/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerKeyTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerKeyTest.java
@@ -1,0 +1,34 @@
+package com.diamonddagger590.mccore.registry.manager;
+
+import com.diamonddagger590.mccore.chat.ChatResponseManager;
+import com.diamonddagger590.mccore.command.CoreCommandManager;
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ManagerKeyTest {
+
+    @Test
+    @DisplayName("Given COMMAND key, when managerClass called, then returns CoreCommandManager class")
+    void command_managerClass_returnsCoreCommandManagerClass() {
+        assertNotNull(ManagerKey.COMMAND);
+        assertEquals(CoreCommandManager.class, ManagerKey.COMMAND.managerClass());
+    }
+
+    @Test
+    @DisplayName("Given RELOADABLE_CONTENT key, when managerClass called, then returns ReloadableContentManager class")
+    void reloadableContent_managerClass_returnsReloadableContentManagerClass() {
+        assertNotNull(ManagerKey.RELOADABLE_CONTENT);
+        assertEquals(ReloadableContentManager.class, ManagerKey.RELOADABLE_CONTENT.managerClass());
+    }
+
+    @Test
+    @DisplayName("Given CHAT_RESPONSE key, when managerClass called, then returns ChatResponseManager class")
+    void chatResponse_managerClass_returnsChatResponseManagerClass() {
+        assertNotNull(ManagerKey.CHAT_RESPONSE);
+        assertEquals(ChatResponseManager.class, ManagerKey.CHAT_RESPONSE.managerClass());
+    }
+}


### PR DESCRIPTION
## Summary

- **DatabaseTableEventsTest**: New test class covering all 4 database table event classes (`PreTablesCreateEvent`, `TablesCreatedEvent`, `PreTablesUpdateEvent`, `TablesUpdatedEvent`) — tests construction, `getHandlers()`, `getHandlerList()`, verifies handler list sharing across instances, and asserts pairwise distinctness across event types. Coverage: 0% → 100%.
- **ManagerKeyTest**: New test class covering the 3 static `ManagerKey` constants (`COMMAND`, `RELOADABLE_CONTENT`, `CHAT_RESPONSE`), verifying each resolves to the correct manager class. Coverage: 0% → 100%.
- **PairTest improvements**: Added direct `equals()` calls for non-Pair objects and null to cover the `!(obj instanceof Pair)` branch, plus null-handling tests for `hashCode()`. Coverage: 94.1% → 100%.
- **ParserTest improvements**: Added error-path tests for trailing tokens after valid expressions, unmatched closing parentheses, and missing function brackets. Strengthened `getInputString` to assert exact sanitized value and `getTree` caching to verify object identity. Coverage: 96.7% → 98.0%.

Overall line coverage improved from 33.0% to 33.5% (1338 → 1360 lines covered out of 4055).

## Test plan

- [x] All 698 tests pass (`./gradlew test`)
- [x] JaCoCo report confirms coverage improvements for all target classes
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2Mb9p5PuTL2bSW5RMWcWF