### PR TITLE
[Tests] Add remaining branch coverage gaps for ManagerRegistry and Methods.lookAt

### DIFF
--- a/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerRegistryTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/registry/manager/ManagerRegistryTest.java
@@ -147,4 +147,18 @@ class ManagerRegistryTest {
         registry().register(subManager);
         assertTrue(registry().registered(new TestManagerASub()));
     }
+
+    @Test
+    @DisplayName("Given only a different manager registered, when checking registered by instance, then returns false")
+    void registered_returnsFalse_whenOnlyNonMatchingManagerRegistered() {
+        registry().register(new TestManagerB());
+        assertFalse(registry().registered(new TestManagerA()));
+    }
+
+    @Test
+    @DisplayName("Given only a different manager registered, when checking registered by key, then returns false")
+    void registered_returnsFalse_whenOnlyNonMatchingManagerRegisteredByKey() {
+        registry().register(new TestManagerB());
+        assertFalse(registry().registered(KEY_A));
+    }
 }

--- a/src/test/java/com/diamonddagger590/mccore/util/MethodsTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/util/MethodsTest.java
@@ -726,6 +726,15 @@ class MethodsTest {
         assertFalse(Float.isInfinite(result.getPitch()), "Pitch should not be infinite");
     }
 
+    @Test
+    @DisplayName("Given target on positive Z with same X, when calculating lookAt, then yaw is zero and pitch is near zero")
+    void lookAt_setsYawToZero_whenTargetIsOnPositiveZWithSameX() {
+        org.bukkit.Location origin = new org.bukkit.Location(null, 0, 0, 0);
+        org.bukkit.Location target = new org.bukkit.Location(null, 0, 0, 10);
+        org.bukkit.Location result = Methods.lookAt(origin, target);
+        assertEquals(0.0, result.getYaw(), 0.01);
+        assertEquals(0.0, result.getPitch(), 0.01);
+    }
 
     // ── getMinecraftKey ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Addresses remaining branch coverage gaps identified during PR #59 persona audit, after rebasing onto latest develop (which merged the original RegistryAccess, StatisticModifyEvent, and prior ManagerRegistry/Methods tests).

- **ManagerRegistry**: Add tests for `registered(Manager)` and `registered(ManagerKey)` with non-matching entries in the map — exercises the for-loop body returning false (rather than the empty-map short path already covered)
- **Methods.lookAt**: Add test for the `dx == 0, dz > 0` branch where yaw stays at 0 — asserts both yaw and pitch for completeness (addresses review feedback about incomplete assertions)

## Coverage Impact

| Class | Branch Before | Branch After |
|-------|:---:|:---:|
| ManagerRegistry | 85.7% (12/14) | **100%** (14/14) |
| Methods.lookAt | already covered | explicit test added |

## Test plan

- [x] All new tests pass (`./gradlew test`)
- [x] Full test suite passes with no regressions
- [x] JaCoCo confirms ManagerRegistry at 100% branch coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PUN8sfRgFi1k1nPoyjGqm