### PR TITLE
[Tests] Add unit tests for BaseItemBuilder, BaseGui, and PlayerSettingDAO

### DIFF
--- a/src/test/java/com/diamonddagger590/mccore/builder/item/BaseItemBuilderTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/builder/item/BaseItemBuilderTest.java
@@ -21,12 +21,15 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -707,6 +710,559 @@ class BaseItemBuilderTest {
             when(newMockItem.getType()).thenReturn(Material.DIAMOND);
             assertSame(builder, builder.setItemStack(newMockItem));
             assertEquals(Material.DIAMOND, builder.getType());
+        }
+    }
+
+    @Nested
+    @DisplayName("Enchantment Glint")
+    class EnchantGlintTests {
+
+        @Test
+        @DisplayName("Given glint enabled without existing data, when setEnchantGlint true, then sets data on item")
+        void setEnchantGlint_setsData_whenEnablingWithoutExistingData() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(false);
+
+            assertSame(builder, builder.setEnchantGlint(true));
+
+            verify(mockItem).setData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true);
+        }
+
+        @Test
+        @DisplayName("Given glint already enabled, when setEnchantGlint true, then does not set data again")
+        void setEnchantGlint_doesNotSetData_whenAlreadyEnabled() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(true);
+
+            builder.setEnchantGlint(true);
+
+            verify(mockItem, never()).setData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true);
+        }
+
+        @Test
+        @DisplayName("Given glint enabled, when setEnchantGlint false, then removes data")
+        void setEnchantGlint_removesData_whenDisablingWithExistingData() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(true);
+
+            builder.setEnchantGlint(false);
+
+            verify(mockItem).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE);
+        }
+
+        @Test
+        @DisplayName("Given glint not set, when setEnchantGlint false, then does nothing")
+        void setEnchantGlint_doesNothing_whenDisablingWithNoExistingData() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(false);
+
+            builder.setEnchantGlint(false);
+
+            verify(mockItem, never()).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE);
+        }
+
+        @Test
+        @DisplayName("Given glint set, when removeEnchantGlint, then removes data")
+        void removeEnchantGlint_removesData_whenGlintExists() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(true);
+
+            assertSame(builder, builder.removeEnchantGlint());
+
+            verify(mockItem).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE);
+        }
+
+        @Test
+        @DisplayName("Given glint not set, when removeEnchantGlint, then does nothing")
+        void removeEnchantGlint_doesNothing_whenGlintNotSet() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE)).thenReturn(false);
+
+            builder.removeEnchantGlint();
+
+            verify(mockItem, never()).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Unbreakable")
+    class UnbreakableTests {
+
+        @Test
+        @DisplayName("Given item is not unbreakable, when setUnbreakable true, then sets data")
+        void setUnbreakable_setsData_whenEnablingOnBreakableItem() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_SWORD);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE)).thenReturn(false);
+
+            assertSame(builder, builder.setUnbreakable(true));
+
+            verify(mockItem).setData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE);
+        }
+
+        @Test
+        @DisplayName("Given item is already unbreakable, when setUnbreakable true, then does not set again")
+        void setUnbreakable_doesNotSetAgain_whenAlreadyUnbreakable() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_SWORD);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE)).thenReturn(true);
+
+            builder.setUnbreakable(true);
+
+            verify(mockItem, never()).setData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE);
+        }
+
+        @Test
+        @DisplayName("Given item is unbreakable, when setUnbreakable false, then removes data")
+        void setUnbreakable_removesData_whenDisablingUnbreakableItem() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_SWORD);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE)).thenReturn(true);
+
+            builder.setUnbreakable(false);
+
+            verify(mockItem).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE);
+        }
+
+        @Test
+        @DisplayName("Given item is breakable, when setUnbreakable false, then does nothing")
+        void setUnbreakable_doesNothing_whenAlreadyBreakable() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_SWORD);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE)).thenReturn(false);
+
+            builder.setUnbreakable(false);
+
+            verify(mockItem, never()).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.UNBREAKABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Max Stack Size")
+    class MaxStackSizeTests {
+
+        @Test
+        @DisplayName("Given a positive value, when setMaxStackSize, then sets data on item")
+        void setMaxStackSize_setsData_whenPositiveValue() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setMaxStackSize(16));
+
+            verify(mockItem).setData(io.papermc.paper.datacomponent.DataComponentTypes.MAX_STACK_SIZE, 16);
+        }
+
+        @Test
+        @DisplayName("Given zero value, when setMaxStackSize, then clamps to 1")
+        void setMaxStackSize_clampsToOne_whenZero() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setMaxStackSize(0);
+
+            verify(mockItem).setData(io.papermc.paper.datacomponent.DataComponentTypes.MAX_STACK_SIZE, 1);
+        }
+
+        @Test
+        @DisplayName("Given negative value, when setMaxStackSize, then clamps to 1")
+        void setMaxStackSize_clampsToOne_whenNegative() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setMaxStackSize(-5);
+
+            verify(mockItem).setData(io.papermc.paper.datacomponent.DataComponentTypes.MAX_STACK_SIZE, 1);
+        }
+    }
+
+    @Nested
+    @DisplayName("withBase64")
+    class WithBase64Tests {
+
+        @Test
+        @DisplayName("Given empty string, when withBase64, then does not change item and returns builder")
+        void withBase64_doesNothing_whenEmptyString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack originalItem = getItemStack(builder);
+
+            assertSame(builder, builder.withBase64(""));
+
+            assertSame(originalItem, getItemStack(builder));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tooltip Management")
+    class TooltipTests {
+
+        @Test
+        @DisplayName("Given no tooltip data, when hideToolTip, then sets tooltip data and returns builder")
+        void hideToolTip_setsData_whenNoExistingTooltip() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY)).thenReturn(false);
+
+            assertSame(builder, builder.hideToolTip());
+
+            verify(mockItem).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.TooltipDisplay.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given tooltip already hidden, when hideToolTip, then does not set data again")
+        void hideToolTip_doesNothing_whenTooltipAlreadyHidden() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY)).thenReturn(true);
+
+            builder.hideToolTip();
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.TooltipDisplay.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given tooltip hidden, when showToolTip, then removes tooltip data and returns builder")
+        void showToolTip_removesData_whenTooltipIsHidden() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY)).thenReturn(true);
+
+            assertSame(builder, builder.showToolTip());
+
+            verify(mockItem).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY);
+        }
+
+        @Test
+        @DisplayName("Given tooltip not hidden, when showToolTip, then does nothing")
+        void showToolTip_doesNothing_whenTooltipNotHidden() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            when(mockItem.hasData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY)).thenReturn(false);
+
+            builder.showToolTip();
+
+            verify(mockItem, never()).unsetData(io.papermc.paper.datacomponent.DataComponentTypes.TOOLTIP_DISPLAY);
+        }
+    }
+
+    @Nested
+    @DisplayName("Item Flags by String")
+    class ItemFlagsByStringTests {
+
+        @Test
+        @DisplayName("Given a valid flag string, when addItemFlag with string, then adds the flag")
+        void addItemFlag_addsFlag_whenValidString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+
+            assertSame(builder, builder.addItemFlag("HIDE_ENCHANTS"));
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertEquals(1, storedFlags.size());
+            assertEquals(ItemFlag.HIDE_ENCHANTS, storedFlags.get(0));
+        }
+
+        @Test
+        @DisplayName("Given an invalid flag string, when addItemFlag with string, then no flag is added")
+        void addItemFlag_doesNotAddFlag_whenInvalidString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+
+            builder.addItemFlag("NOT_A_REAL_FLAG");
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertTrue(storedFlags.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given a list of valid flag strings, when addItemFlags, then adds all flags")
+        void addItemFlags_addsAllFlags_whenValidStrings() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+
+            assertSame(builder, builder.addItemFlags(List.of("HIDE_ENCHANTS", "HIDE_ATTRIBUTES")));
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertEquals(2, storedFlags.size());
+            assertTrue(storedFlags.contains(ItemFlag.HIDE_ENCHANTS));
+            assertTrue(storedFlags.contains(ItemFlag.HIDE_ATTRIBUTES));
+        }
+
+        @Test
+        @DisplayName("Given an empty list, when addItemFlags, then no flags are added")
+        void addItemFlags_addsNothing_whenEmptyList() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+
+            builder.addItemFlags(List.of());
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertTrue(storedFlags.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given a list of valid flag strings, when removeItemFlags, then removes matching flags")
+        void removeItemFlags_removesFlags_whenValid() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            builder.addItemFlag(ItemFlag.HIDE_ENCHANTS);
+            builder.addItemFlag(ItemFlag.HIDE_ATTRIBUTES);
+
+            assertSame(builder, builder.removeItemFlags(List.of("HIDE_ENCHANTS")));
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertEquals(1, storedFlags.size());
+            assertEquals(ItemFlag.HIDE_ATTRIBUTES, storedFlags.get(0));
+        }
+
+        @Test
+        @DisplayName("Given a valid flag string, when removeItemFlag by string, then removes the flag")
+        void removeItemFlag_removesFlag_whenValidString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            builder.addItemFlag(ItemFlag.HIDE_ENCHANTS);
+
+            assertSame(builder, builder.removeItemFlag("HIDE_ENCHANTS"));
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertTrue(storedFlags.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given an invalid flag string, when removeItemFlag by string, then no flag is removed")
+        void removeItemFlag_doesNothing_whenInvalidString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            builder.addItemFlag(ItemFlag.HIDE_ENCHANTS);
+
+            builder.removeItemFlag("NOT_A_REAL_FLAG");
+
+            List<ItemFlag> storedFlags = getField(BaseItemBuilder.class, builder, "itemFlags");
+            assertEquals(1, storedFlags.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Custom Model Data")
+    class CustomModelDataTests {
+
+        @Test
+        @DisplayName("Given -1, when setCustomModelData, then does not set data and returns builder")
+        void setCustomModelData_doesNothing_whenNegativeOne() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setCustomModelData(-1));
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.CUSTOM_MODEL_DATA),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.CustomModelData.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given a positive value, when setCustomModelData, then sets data on item")
+        void setCustomModelData_setsData_whenPositiveValue() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setCustomModelData(42);
+
+            verify(mockItem).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.CUSTOM_MODEL_DATA),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.CustomModelData.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given zero, when setCustomModelData, then sets data on item")
+        void setCustomModelData_setsData_whenZero() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setCustomModelData(0);
+
+            verify(mockItem).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.CUSTOM_MODEL_DATA),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.CustomModelData.class)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Item Model")
+    class ItemModelTests {
+
+        @Test
+        @DisplayName("Given empty string, when setItemModel, then does not set data and returns builder")
+        void setItemModel_doesNothing_whenEmptyString() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setItemModel(""));
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.ITEM_MODEL),
+                    org.mockito.ArgumentMatchers.any(org.bukkit.NamespacedKey.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given a valid model name, when setItemModel with single arg, then sets data")
+        void setItemModel_setsData_whenValidName() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setItemModel("custom_sword");
+
+            verify(mockItem).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.ITEM_MODEL),
+                    org.mockito.ArgumentMatchers.eq(org.bukkit.NamespacedKey.minecraft("custom_sword"))
+            );
+        }
+
+        @Test
+        @DisplayName("Given empty item model, when setItemModel with namespace, then does not set data")
+        void setItemModel_doesNothing_whenEmptyModelWithNamespace() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setItemModel("myplugin", ""));
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.ITEM_MODEL),
+                    org.mockito.ArgumentMatchers.any(org.bukkit.NamespacedKey.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given valid namespace and model, when setItemModel with two args, then sets data")
+        void setItemModel_setsData_whenValidNamespaceAndModel() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+
+            builder.setItemModel("myplugin", "custom_axe");
+
+            verify(mockItem).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.ITEM_MODEL),
+                    org.mockito.ArgumentMatchers.eq(new org.bukkit.NamespacedKey("myplugin", "custom_axe"))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Inventory Methods")
+    class InventoryMethodTests {
+
+        @Test
+        @DisplayName("Given an inventory and slot, when setItemToInventory with null audience, then sets item at slot")
+        void setItemToInventory_setsItem_whenNullAudience() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            ItemStack clonedItem = mock(ItemStack.class);
+            when(mockItem.clone()).thenReturn(clonedItem);
+            org.bukkit.inventory.Inventory mockInventory = mock(org.bukkit.inventory.Inventory.class);
+
+            builder.setItemToInventory(mockInventory, 5);
+
+            verify(mockInventory).setItem(org.mockito.ArgumentMatchers.eq(5), org.mockito.ArgumentMatchers.any(ItemStack.class));
+        }
+
+        @Test
+        @DisplayName("Given an inventory, when addItemToInventory with null audience, then adds item to inventory")
+        void addItemToInventory_addsItem_whenNullAudience() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            ItemStack mockItem = getItemStack(builder);
+            ItemStack clonedItem = mock(ItemStack.class);
+            when(mockItem.clone()).thenReturn(clonedItem);
+            org.bukkit.inventory.Inventory mockInventory = mock(org.bukkit.inventory.Inventory.class);
+
+            builder.addItemToInventory(mockInventory);
+
+            verify(mockInventory).addItem(org.mockito.ArgumentMatchers.any(ItemStack.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Trim")
+    class TrimTests {
+
+        @Test
+        @DisplayName("Given empty pattern string, when setTrim with strings, then does not set data")
+        void setTrim_doesNothing_whenPatternIsEmpty() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_CHESTPLATE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setTrim("", "iron"));
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.TRIM),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.ItemArmorTrim.class)
+            );
+        }
+
+        @Test
+        @DisplayName("Given empty material string, when setTrim with strings, then does not set data")
+        void setTrim_doesNothing_whenMaterialIsEmpty() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_CHESTPLATE);
+            ItemStack mockItem = getItemStack(builder);
+
+            assertSame(builder, builder.setTrim("sentry", ""));
+
+            verify(mockItem, never()).setData(
+                    org.mockito.ArgumentMatchers.eq(io.papermc.paper.datacomponent.DataComponentTypes.TRIM),
+                    org.mockito.ArgumentMatchers.any(io.papermc.paper.datacomponent.item.ItemArmorTrim.class)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Display Name with Component Clearing")
+    class DisplayNameComponentTests {
+
+        @Test
+        @DisplayName("Given a builder with displayNameComponent, when setDisplayName is called, then displayNameComponent is cleared")
+        void setDisplayName_clearsComponent_whenComponentWasSet() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            setField(BaseItemBuilder.class, builder, "displayNameComponent", Component.text("Old Component"));
+
+            builder.setDisplayName("New Name", true);
+
+            Component storedComponent = getField(BaseItemBuilder.class, builder, "displayNameComponent");
+            assertNull(storedComponent);
+            String storedName = getField(BaseItemBuilder.class, builder, "displayName");
+            assertEquals("New Name", storedName);
+        }
+
+        @Test
+        @DisplayName("Given a builder, when setDisplayName with staticItemName false, then stores correctly")
+        void setDisplayName_storesStaticFlag_whenExplicitlySet() {
+            ItemBuilder builder = createBuilder(Material.STONE);
+            builder.setDisplayName("Dynamic", false);
+
+            boolean staticFlag = getField(BaseItemBuilder.class, builder, "staticItemName");
+            assertFalse(staticFlag);
+        }
+    }
+
+    @Nested
+    @DisplayName("Enchantment Removal")
+    class EnchantmentRemovalTests {
+
+        @Test
+        @DisplayName("Given a builder, when removeEnchantment with Enchantment, then delegates to item stack")
+        void removeEnchantment_delegatesToItemStack_whenEnchantmentProvided() {
+            ItemBuilder builder = createBuilder(Material.DIAMOND_SWORD);
+            ItemStack mockItem = getItemStack(builder);
+            org.bukkit.enchantments.Enchantment mockEnchant = mock(org.bukkit.enchantments.Enchantment.class);
+
+            assertSame(builder, builder.removeEnchantment(mockEnchant));
+
+            verify(mockItem).removeEnchantment(mockEnchant);
         }
     }
 }

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/PlayerSettingDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/PlayerSettingDAOTest.java
@@ -38,7 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -184,6 +186,7 @@ class PlayerSettingDAOTest {
             PlayerSettingDAO.updateTable(mockConnection);
 
             verify(updateStatement).setString(1, "player_settings");
+            verify(updateStatement).setTime(eq(2), any(java.sql.Time.class));
             verify(updateStatement).setInt(3, 1);
             verify(updateStatement).executeUpdate();
         }

--- a/src/test/java/com/diamonddagger590/mccore/database/table/impl/PlayerSettingDAOTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/database/table/impl/PlayerSettingDAOTest.java
@@ -1,0 +1,414 @@
+package com.diamonddagger590.mccore.database.table.impl;
+
+import com.diamonddagger590.mccore.CorePlugin;
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.exception.setting.SettingNotRegisteredException;
+import com.diamonddagger590.mccore.player.CorePlayer;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.setting.PlayerSetting;
+import com.diamonddagger590.mccore.setting.PlayerSettingRegistry;
+import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import com.diamonddagger590.mccore.util.LinkedNode;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerSettingDAOTest {
+
+    @Mock
+    private Connection mockConnection;
+
+    @Mock
+    private PreparedStatement mockStatement;
+
+    @Mock
+    private ResultSet mockResultSet;
+
+    @Mock
+    private Database mockDatabase;
+
+    private static final UUID TEST_UUID = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+
+    private enum TestSetting implements PlayerSetting {
+        ON,
+        OFF;
+
+        private static final NamespacedKey KEY = new NamespacedKey("mccore", "test_setting");
+
+        @Override
+        @NotNull
+        public NamespacedKey getSettingKey() {
+            return KEY;
+        }
+
+        @Override
+        @NotNull
+        public LinkedNode<TestSetting> getFirstSetting() {
+            return new LinkedNode<>(ON, new LinkedNode<>(OFF, null));
+        }
+
+        @Override
+        @NotNull
+        public LinkedNode<TestSetting> getNextSetting() {
+            return this == ON ? new LinkedNode<>(OFF, null) : new LinkedNode<>(ON, null);
+        }
+
+        @Override
+        public void onSettingChange(@NotNull CorePlayer player, @NotNull Optional<PlayerSetting> oldSetting) {
+        }
+
+        @Override
+        @NotNull
+        public Optional<TestSetting> fromString(@NotNull String setting) {
+            try {
+                return Optional.of(TestSetting.valueOf(setting));
+            } catch (IllegalArgumentException e) {
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @Test
+        @DisplayName("Given the table already exists, when attemptCreateTable is called, then returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "player_settings")).thenReturn(true);
+
+            boolean result = PlayerSettingDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given the table doesn't exist, when attemptCreateTable is called, then creates table and index and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreatedSuccessfully() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "player_settings")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = PlayerSettingDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception during table creation, when attemptCreateTable is called, then returns false")
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOnCreate() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "player_settings")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Create failed"));
+
+            boolean result = PlayerSettingDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception during index creation, when attemptCreateTable is called, then returns false")
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOnIndex() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "player_settings")).thenReturn(false);
+            PreparedStatement createTableStmt = mock(PreparedStatement.class);
+            PreparedStatement indexStmt = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString()))
+                    .thenReturn(createTableStmt)
+                    .thenThrow(new SQLException("Index failed"));
+
+            boolean result = PlayerSettingDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @Test
+        @DisplayName("Given the table is at current version, when updateTable is called, then no updates are performed")
+        void updateTable_performsNoUpdate_whenVersionIsCurrent() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt("table_version")).thenReturn(1);
+
+            PlayerSettingDAO.updateTable(mockConnection);
+        }
+
+        @Test
+        @DisplayName("Given the table is at version 0, when updateTable is called, then it updates to version 1")
+        void updateTable_updatesToVersion1_whenVersionIsZero() throws SQLException {
+            PreparedStatement selectStatement = mock(PreparedStatement.class);
+            ResultSet selectResultSet = mock(ResultSet.class);
+            when(selectStatement.executeQuery()).thenReturn(selectResultSet);
+            when(selectResultSet.next()).thenReturn(false);
+
+            PreparedStatement updateStatement = mock(PreparedStatement.class);
+
+            when(mockConnection.prepareStatement(anyString()))
+                    .thenReturn(selectStatement)
+                    .thenReturn(updateStatement);
+
+            PlayerSettingDAO.updateTable(mockConnection);
+
+            verify(updateStatement).setString(1, "player_settings");
+            verify(updateStatement).setInt(3, 1);
+            verify(updateStatement).executeUpdate();
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerSettings")
+    class GetPlayerSettings {
+
+        private MockedStatic<CorePlugin> corePluginStatic;
+
+        @BeforeEach
+        void setUp() {
+            RegistryResetExtension.setupRegistry();
+
+            PlayerSettingRegistry registry = RegistryAccess.registryAccess().registry(RegistryKey.PLAYER_SETTING);
+            registry.register(TestSetting.ON);
+
+            CorePlugin mockPlugin = mock(CorePlugin.class);
+            when(mockPlugin.registryAccess()).thenReturn(RegistryAccess.registryAccess());
+            when(mockPlugin.getLogger()).thenReturn(Logger.getLogger("TestLogger"));
+
+            corePluginStatic = mockStatic(CorePlugin.class);
+            corePluginStatic.when(CorePlugin::getInstance).thenReturn(mockPlugin);
+        }
+
+        @AfterEach
+        void tearDown() {
+            corePluginStatic.close();
+            RegistryResetExtension.resetRegistry();
+        }
+
+        @Test
+        @DisplayName("Given player has saved settings, when getPlayerSettings is called, then returns settings from database")
+        void getPlayerSettings_returnsFromDatabase_whenSettingSaved() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("setting_value")).thenReturn("OFF");
+
+            Set<PlayerSetting> settings = PlayerSettingDAO.getPlayerSettings(mockConnection, TEST_UUID);
+
+            assertFalse(settings.isEmpty());
+            assertEquals(1, settings.size());
+            assertTrue(settings.stream().anyMatch(s -> s.name().equals("OFF")));
+        }
+
+        @Test
+        @DisplayName("Given player has no saved settings, when getPlayerSettings is called, then returns defaults")
+        void getPlayerSettings_returnsDefaults_whenNoSettingSaved() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            Set<PlayerSetting> settings = PlayerSettingDAO.getPlayerSettings(mockConnection, TEST_UUID);
+
+            assertFalse(settings.isEmpty());
+            assertEquals(1, settings.size());
+            assertTrue(settings.stream().anyMatch(s -> s.name().equals("ON")));
+        }
+
+        @Test
+        @DisplayName("Given player has invalid saved setting, when getPlayerSettings is called, then returns default")
+        void getPlayerSettings_returnsDefault_whenInvalidSettingValue() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("setting_value")).thenReturn("INVALID_VALUE");
+
+            Set<PlayerSetting> settings = PlayerSettingDAO.getPlayerSettings(mockConnection, TEST_UUID);
+
+            assertFalse(settings.isEmpty());
+            assertEquals(1, settings.size());
+            assertTrue(settings.stream().anyMatch(s -> s.name().equals("ON")));
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception occurs, when getPlayerSettings is called, then returns partial results")
+        void getPlayerSettings_returnsPartialResults_whenSqlExceptionOccurs() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Query failed"));
+
+            Set<PlayerSetting> settings = PlayerSettingDAO.getPlayerSettings(mockConnection, TEST_UUID);
+
+            assertNotNull(settings);
+            assertTrue(settings.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerSetting")
+    class GetPlayerSetting {
+
+        private MockedStatic<CorePlugin> corePluginStatic;
+
+        @BeforeEach
+        void setUp() {
+            RegistryResetExtension.setupRegistry();
+
+            PlayerSettingRegistry registry = RegistryAccess.registryAccess().registry(RegistryKey.PLAYER_SETTING);
+            registry.register(TestSetting.ON);
+
+            CorePlugin mockPlugin = mock(CorePlugin.class);
+            when(mockPlugin.registryAccess()).thenReturn(RegistryAccess.registryAccess());
+
+            corePluginStatic = mockStatic(CorePlugin.class);
+            corePluginStatic.when(CorePlugin::getInstance).thenReturn(mockPlugin);
+        }
+
+        @AfterEach
+        void tearDown() {
+            corePluginStatic.close();
+            RegistryResetExtension.resetRegistry();
+        }
+
+        @Test
+        @DisplayName("Given unregistered setting key, when getPlayerSetting is called, then throws SettingNotRegisteredException")
+        void getPlayerSetting_throwsException_whenSettingNotRegistered() {
+            NamespacedKey unknownKey = new NamespacedKey("mccore", "unknown_setting");
+
+            assertThrows(SettingNotRegisteredException.class,
+                    () -> PlayerSettingDAO.getPlayerSetting(mockConnection, TEST_UUID, unknownKey));
+        }
+
+        @Test
+        @DisplayName("Given a saved setting value, when getPlayerSetting is called, then returns saved value")
+        void getPlayerSetting_returnsSavedValue_whenPresent() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("setting_value")).thenReturn("OFF");
+
+            PlayerSetting result = PlayerSettingDAO.getPlayerSetting(mockConnection, TEST_UUID, TestSetting.ON.getSettingKey());
+
+            assertEquals("OFF", result.name());
+        }
+
+        @Test
+        @DisplayName("Given no saved setting, when getPlayerSetting is called, then returns default")
+        void getPlayerSetting_returnsDefault_whenNoSavedValue() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            PlayerSetting result = PlayerSettingDAO.getPlayerSetting(mockConnection, TEST_UUID, TestSetting.ON.getSettingKey());
+
+            assertEquals("ON", result.name());
+        }
+
+        @Test
+        @DisplayName("Given an invalid saved value, when getPlayerSetting is called, then returns default")
+        void getPlayerSetting_returnsDefault_whenInvalidSavedValue() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("setting_value")).thenReturn("INVALID");
+
+            PlayerSetting result = PlayerSettingDAO.getPlayerSetting(mockConnection, TEST_UUID, TestSetting.ON.getSettingKey());
+
+            assertEquals("ON", result.name());
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception, when getPlayerSetting is called, then returns default")
+        void getPlayerSetting_returnsDefault_whenSqlExceptionOccurs() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Query failed"));
+
+            PlayerSetting result = PlayerSettingDAO.getPlayerSetting(mockConnection, TEST_UUID, TestSetting.ON.getSettingKey());
+
+            assertEquals("ON", result.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("savePlayerSetting")
+    class SavePlayerSetting {
+
+        @Test
+        @DisplayName("Given a valid player setting, when savePlayerSetting is called, then returns a prepared statement")
+        void savePlayerSetting_returnsPreparedStatement_whenValid() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            PreparedStatement result = PlayerSettingDAO.savePlayerSetting(mockConnection, TEST_UUID, TestSetting.ON);
+
+            assertNotNull(result);
+            verify(mockStatement).setString(1, TEST_UUID.toString());
+            verify(mockStatement).setString(2, TestSetting.ON.getSettingKey().toString());
+            verify(mockStatement).setString(3, "ON");
+        }
+
+        @Test
+        @DisplayName("Given a SQL exception, when savePlayerSetting is called, then throws RuntimeException")
+        void savePlayerSetting_throwsRuntimeException_whenSqlExceptionOccurs() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Save failed"));
+
+            assertThrows(RuntimeException.class,
+                    () -> PlayerSettingDAO.savePlayerSetting(mockConnection, TEST_UUID, TestSetting.ON));
+        }
+    }
+
+    @Nested
+    @DisplayName("savePlayerSettings")
+    class SavePlayerSettings {
+
+        @Test
+        @DisplayName("Given a set of settings, when savePlayerSettings is called, then returns list of prepared statements")
+        void savePlayerSettings_returnsList_whenMultipleSettings() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            Set<PlayerSetting> settings = new HashSet<>();
+            settings.add(TestSetting.ON);
+            settings.add(TestSetting.OFF);
+
+            List<PreparedStatement> results = PlayerSettingDAO.savePlayerSettings(mockConnection, TEST_UUID, settings);
+
+            assertEquals(2, results.size());
+        }
+
+        @Test
+        @DisplayName("Given an empty set, when savePlayerSettings is called, then returns empty list")
+        void savePlayerSettings_returnsEmptyList_whenNoSettings() {
+            Set<PlayerSetting> settings = new HashSet<>();
+
+            List<PreparedStatement> results = PlayerSettingDAO.savePlayerSettings(mockConnection, TEST_UUID, settings);
+
+            assertTrue(results.isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/diamonddagger590/mccore/gui/BaseGuiTest.java
+++ b/src/test/java/com/diamonddagger590/mccore/gui/BaseGuiTest.java
@@ -1,18 +1,32 @@
 package com.diamonddagger590.mccore.gui;
 
 import com.diamonddagger590.mccore.CorePlugin;
+import com.diamonddagger590.mccore.builder.item.impl.ItemBuilder;
 import com.diamonddagger590.mccore.exception.gui.IllegalSlotAssignmentException;
 import com.diamonddagger590.mccore.gui.slot.Slot;
 import com.diamonddagger590.mccore.player.CorePlayer;
+import com.diamonddagger590.mccore.player.PlayerManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.registry.manager.CoreManagerKey;
+import com.diamonddagger590.mccore.registry.manager.ManagerRegistry;
+import com.diamonddagger590.mccore.testing.RegistryResetExtension;
+import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -22,7 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class BaseGuiTest {
@@ -267,6 +287,270 @@ class BaseGuiTest {
             RestrictedSlot restrictedSlot = new RestrictedSlot(validTypes);
 
             assertThrows(IllegalSlotAssignmentException.class, () -> gui.setSlot(0, restrictedSlot));
+        }
+    }
+
+    @Nested
+    @DisplayName("setSlot success path")
+    class SetSlotSuccess {
+
+        @Test
+        @DisplayName("Given valid unrestricted slot with online player, when setSlot at valid index, then stores slot and sets item in inventory")
+        void setSlot_storesSlotAndSetsItem_whenValid() {
+            gui.getInventory();
+
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+
+            ItemBuilder mockItemBuilder = mock(ItemBuilder.class);
+            ItemStack mockItemStack = mock(ItemStack.class);
+            when(mockItemBuilder.asItemStack(any())).thenReturn(mockItemStack);
+
+            Slot<TestCorePlayer> slot = new Slot<>() {
+                @Override
+                public boolean onClick(@NotNull TestCorePlayer corePlayer, @NotNull ClickType clickType) {
+                    return true;
+                }
+
+                @Override
+                @NotNull
+                public ItemBuilder getItem(@NotNull TestCorePlayer corePlayer) {
+                    return mockItemBuilder;
+                }
+            };
+
+            try (MockedStatic<org.bukkit.Bukkit> bukkitStatic = mockStatic(org.bukkit.Bukkit.class)) {
+                bukkitStatic.when(() -> org.bukkit.Bukkit.getPlayer(player.getUUID())).thenReturn(mockBukkitPlayer);
+
+                gui.setSlot(0, slot);
+
+                assertSame(slot, gui.getSlot(0));
+                verify(mockInventory).setItem(eq(0), eq(mockItemStack));
+            }
+        }
+
+        @Test
+        @DisplayName("Given null inventory, when setSlot, then throws NullPointerException")
+        void setSlot_throwsNPE_whenInventoryIsNull() {
+            Slot<TestCorePlayer> slot = new Slot<>() {
+                @Override
+                public boolean onClick(@NotNull TestCorePlayer corePlayer, @NotNull ClickType clickType) {
+                    return false;
+                }
+            };
+
+            assertThrows(NullPointerException.class, () -> gui.setSlot(0, slot));
+        }
+    }
+
+    @Nested
+    @DisplayName("canProcessEvent")
+    class CanProcessEvent {
+
+        private MockedStatic<CorePlugin> corePluginStatic;
+        private GuiManager<TestCorePlayer, CorePlugin> mockGuiManager;
+
+        @SuppressWarnings("unchecked")
+        @BeforeEach
+        void setUpStatic() {
+            RegistryResetExtension.setupRegistry();
+
+            mockGuiManager = mock(GuiManager.class);
+
+            ManagerRegistry managerRegistry = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER);
+            managerRegistry.register(mockGuiManager);
+
+            CorePlugin mockPlugin = mock(CorePlugin.class);
+            when(mockPlugin.registryAccess()).thenReturn(RegistryAccess.registryAccess());
+
+            corePluginStatic = mockStatic(CorePlugin.class);
+            corePluginStatic.when(CorePlugin::getInstance).thenReturn(mockPlugin);
+        }
+
+        @AfterEach
+        void tearDownStatic() {
+            corePluginStatic.close();
+            RegistryResetExtension.resetRegistry();
+        }
+
+        @Test
+        @DisplayName("Given player has this gui open and inventory matches, when canProcessEvent, then returns true")
+        void canProcessEvent_returnsTrue_whenPlayerHasThisGuiOpenAndInventoryMatches() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.of(gui));
+
+            boolean result = gui.canProcessEvent(mockBukkitPlayer, mockInventory);
+
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("Given player has different gui open, when canProcessEvent, then returns false")
+        void canProcessEvent_returnsFalse_whenPlayerHasDifferentGuiOpen() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            TestGui otherGui = new TestGui(player, mock(Inventory.class));
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.of(otherGui));
+
+            boolean result = gui.canProcessEvent(mockBukkitPlayer, mockInventory);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given player has no gui open, when canProcessEvent, then returns false")
+        void canProcessEvent_returnsFalse_whenPlayerHasNoGuiOpen() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.empty());
+
+            boolean result = gui.canProcessEvent(mockBukkitPlayer, mockInventory);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given wrong inventory, when canProcessEvent, then returns false")
+        void canProcessEvent_returnsFalse_whenInventoryDoesNotMatch() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            Inventory differentInventory = mock(Inventory.class);
+
+            boolean result = gui.canProcessEvent(mockBukkitPlayer, differentInventory);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleClickEvent")
+    class HandleClickEvent {
+
+        private MockedStatic<CorePlugin> corePluginStatic;
+        @SuppressWarnings("rawtypes")
+        private GuiManager mockGuiManager;
+        @SuppressWarnings("rawtypes")
+        private PlayerManager mockPlayerManager;
+
+        @SuppressWarnings("unchecked")
+        @BeforeEach
+        void setUpStatic() {
+            RegistryResetExtension.setupRegistry();
+
+            mockGuiManager = mock(GuiManager.class);
+            mockPlayerManager = mock(PlayerManager.class);
+
+            ManagerRegistry managerRegistry = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER);
+            managerRegistry.register(mockGuiManager);
+            managerRegistry.register(mockPlayerManager);
+
+            CorePlugin mockPlugin = mock(CorePlugin.class);
+            when(mockPlugin.registryAccess()).thenReturn(RegistryAccess.registryAccess());
+
+            corePluginStatic = mockStatic(CorePlugin.class);
+            corePluginStatic.when(CorePlugin::getInstance).thenReturn(mockPlugin);
+        }
+
+        @AfterEach
+        void tearDownStatic() {
+            corePluginStatic.close();
+            RegistryResetExtension.resetRegistry();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("Given bottom inventory clicked and bottom click not allowed, when handleClickEvent, then cancels event")
+        void handleClickEvent_cancelsEvent_whenBottomInventoryClickedAndNotAllowed() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.of(gui));
+            when(mockPlayerManager.getPlayer(player.getUUID())).thenReturn(Optional.of(player));
+
+            InventoryClickEvent event = mock(InventoryClickEvent.class);
+            when(event.getSlot()).thenReturn(0);
+            when(event.getWhoClicked()).thenReturn(mockBukkitPlayer);
+
+            InventoryView mockView = mock(InventoryView.class);
+            when(event.getView()).thenReturn(mockView);
+            when(mockView.getTopInventory()).thenReturn(mockInventory);
+
+            Inventory bottomInventory = mock(Inventory.class);
+            when(mockView.getBottomInventory()).thenReturn(bottomInventory);
+            when(event.getClickedInventory()).thenReturn(bottomInventory);
+
+            gui.handleClickEvent(event);
+
+            verify(event).setCancelled(true);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("Given canProcessEvent returns false, when handleClickEvent, then does not cancel event")
+        void handleClickEvent_doesNotCancel_whenCanProcessEventReturnsFalse() {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.empty());
+            when(mockPlayerManager.getPlayer(player.getUUID())).thenReturn(Optional.of(player));
+
+            InventoryClickEvent event = mock(InventoryClickEvent.class);
+            when(event.getSlot()).thenReturn(0);
+            when(event.getWhoClicked()).thenReturn(mockBukkitPlayer);
+
+            InventoryView mockView = mock(InventoryView.class);
+            when(event.getView()).thenReturn(mockView);
+            when(mockView.getTopInventory()).thenReturn(mockInventory);
+
+            gui.handleClickEvent(event);
+
+            verify(event, never()).setCancelled(true);
+            verify(event, never()).setCancelled(false);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("Given top inventory clicked with valid player, when handleClickEvent, then delegates to slot onClick")
+        void handleClickEvent_delegatesToSlot_whenTopInventoryClicked() throws Exception {
+            gui.getInventory();
+            Player mockBukkitPlayer = mock(Player.class);
+            when(mockBukkitPlayer.getUniqueId()).thenReturn(player.getUUID());
+            when(mockGuiManager.getOpenedGui(mockBukkitPlayer)).thenReturn(Optional.of(gui));
+            when(mockPlayerManager.getPlayer(player.getUUID())).thenReturn(Optional.of(player));
+
+            Slot<TestCorePlayer> customSlot = new Slot<>() {
+                @Override
+                public boolean onClick(@NotNull TestCorePlayer corePlayer, @NotNull ClickType clickType) {
+                    return true;
+                }
+            };
+
+            java.lang.reflect.Field slotsField = BaseGui.class.getDeclaredField("slots");
+            slotsField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.Map<Integer, Slot<TestCorePlayer>> slots =
+                    (java.util.Map<Integer, Slot<TestCorePlayer>>) slotsField.get(gui);
+            slots.put(3, customSlot);
+
+            InventoryClickEvent event = mock(InventoryClickEvent.class);
+            when(event.getSlot()).thenReturn(3);
+            when(event.getClick()).thenReturn(ClickType.LEFT);
+            when(event.getWhoClicked()).thenReturn(mockBukkitPlayer);
+
+            InventoryView mockView = mock(InventoryView.class);
+            when(event.getView()).thenReturn(mockView);
+            when(mockView.getTopInventory()).thenReturn(mockInventory);
+            when(mockView.getBottomInventory()).thenReturn(mock(Inventory.class));
+            when(event.getClickedInventory()).thenReturn(mockInventory);
+
+            gui.handleClickEvent(event);
+
+            verify(event).setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **BaseItemBuilderTest**: Added 39 new tests covering enchant glint (6), unbreakable (4), max stack size (3), withBase64 (1), tooltip management (4), item flags by string (7), custom model data (3), item model (4), inventory methods (2), trim (2), display name component clearing (2), and enchantment removal (1).
- **BaseGuiTest**: Added 9 new tests covering setSlot success path (2), canProcessEvent all branches (4), and handleClickEvent bottom/top inventory delegation and canProcessEvent false path (3).
- **PlayerSettingDAOTest**: Created new test file with 18 tests covering attemptCreateTable (4), updateTable (2), getPlayerSettings (4), getPlayerSetting (4), savePlayerSetting (2), and savePlayerSettings (2).

## Details

Total of 66 new tests added across 3 files. All tests pass. No production code was changed.

BaseItemBuilder tests use the existing Mockito partial mock + reflection pattern (since `DataComponentTypes` cannot initialize without a Paper server). BaseGui tests use `MockedStatic<CorePlugin>` and `RegistryResetExtension` to wire up mock `GuiManager`/`PlayerManager` through the registry system. PlayerSettingDAO tests use standard Mockito JDBC mocking with a `TestSetting` enum implementing `PlayerSetting`.

## Test plan

- [x] All 66 new tests pass (`gradle test --tests "...BaseItemBuilderTest" --tests "...BaseGuiTest" --tests "...PlayerSettingDAOTest"`)
- [x] No pre-existing tests broken by these changes
- [x] Testing audit persona reviewed — no concerns found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NGGi42tE6SLPGiFoFxERs

---
_Generated by [Claude Code](https://claude.ai/code/session_015NGGi42tE6SLPGiFoFxERs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for item builder features, including enchantment glint, unbreakable items, stack sizes, tooltips, models, trims, flags, and custom data.
  * Added database tests covering player-setting creation, retrieval, updates, saving, defaults, and error handling.
  * Added GUI tests for slot assignment, inventory validation, event processing, click cancellation, and custom slot handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->